### PR TITLE
Prepare L++ repository for GitHub Linguist submission

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,14 @@
+# Generated benchmark reports should not affect GitHub language statistics.
+benchmarks/Benchmarks.md linguist-generated=true
+benchmarks/results.md linguist-generated=true
+benchmarks/comparison/latest.json linguist-generated=true
+benchmarks/comparison/latest.md linguist-generated=true
+benchmarks/king20/**/latest.json linguist-generated=true
+benchmarks/king20/**/latest.md linguist-generated=true
+benchmarks/scalability/generated/** linguist-generated=true
+benchmarks/scalability/latest.json linguist-generated=true
+benchmarks/scalability/latest.md linguist-generated=true
+
+# Generated compiler outputs are documentation/test artifacts, not language source.
+benchmarks/**/*.o linguist-generated=true
+benchmarks/**/*.exe linguist-generated=true

--- a/README.md
+++ b/README.md
@@ -103,6 +103,12 @@ python3 benchmarks/comparison/run.py
 
 Missing toolchains are recorded as `SKIP`; they are never reported as benchmark values. See [`benchmarks/comparison/README.md`](benchmarks/comparison/README.md) for methodology.
 
+## GitHub language recognition
+
+L++ source uses the `.lpp` extension and the maintained VS Code TextMate scope `source.lpp`. Generated benchmark reports are marked with `linguist-generated=true` in `.gitattributes`, so they do not distort repository language statistics.
+
+Global GitHub language-bar recognition requires an upstream GitHub Linguist contribution; it cannot be forced by repository metadata alone. The maintained submission package is in [`linguist/UPSTREAM_LINGUIST_PR.md`](linguist/UPSTREAM_LINGUIST_PR.md), with a representative sample at [`linguist/samples/lpp/ownership_and_closures.lpp`](linguist/samples/lpp/ownership_and_closures.lpp).
+
 ## Getting Started
 
 Check out [Doc.md](Doc.md) for a comprehensive guide on the syntax and semantics of L++.

--- a/linguist/UPSTREAM_LINGUIST_PR.md
+++ b/linguist/UPSTREAM_LINGUIST_PR.md
@@ -1,0 +1,40 @@
+# L++ GitHub Linguist submission package
+
+This repository is prepared for an upstream language-recognition contribution to [`github-linguist`](https://github.com/github-linguist).
+
+## Canonical language identity
+
+| Item | Value |
+|---|---|
+| Display name | L++ |
+| Common name | L Plus Plus |
+| File extension | `.lpp` |
+| Programming-language scope | `source.lpp` |
+| Existing grammar | `editors/vscode/syntaxes/lpp.tmLanguage.json` |
+| VS Code language ID | `lpp` |
+| Representative sample | `linguist/samples/lpp/ownership_and_closures.lpp` |
+
+## Why this repository alone cannot force GitHub recognition
+
+GitHub language statistics are driven by the upstream Linguist language database. A repository README, file extension, or `.gitattributes` entry cannot create a new globally recognized language. L++ needs an upstream Linguist pull request adding its language definition and grammar metadata.
+
+## Upstream PR checklist
+
+1. Fork `github-linguist` and create a focused branch.
+2. Add an L++ entry to Linguist's language metadata with a new unique language ID.
+3. Register `.lpp` as the extension and `source.lpp` as the TextMate scope.
+4. Provide or reference the maintained TextMate grammar in this repository.
+5. Add a representative `.lpp` sample from this directory.
+6. Run the upstream Linguist test suite and language-detection checks.
+7. Open the upstream pull request with a link to this repository and its VS Code grammar.
+
+## Repository-side readiness
+
+- `.gitattributes` marks generated benchmark reports as `linguist-generated=true`.
+- Benchmark reports no longer distort source-language statistics.
+- The committed sample demonstrates indentation, comments, typed functions, structs, closures, lists, conditionals, and function calls.
+- The VS Code grammar is versioned in this repository rather than being only a binary extension artifact.
+
+## Important distinction
+
+This repository can open a **readiness PR** for its own metadata and samples. The actual global `L++` label in GitHub's language bar requires acceptance by the upstream `github-linguist` project.

--- a/linguist/samples/lpp/ownership_and_closures.lpp
+++ b/linguist/samples/lpp/ownership_and_closures.lpp
@@ -1,0 +1,19 @@
+# L++ Linguist sample: significant whitespace, typed functions, closures,
+# ARC-managed custom values, lists, and control flow.
+
+struct Box:
+    value: Int
+
+def identity(value: Box) -> Box:
+    return value
+
+def main():
+    original := Box()
+    copied := identity(original)
+    values := [1, 2, 3]
+    reader := fn() -> Int:
+        if list_len(values) > 0:
+            return copied.value
+        else:
+            return 0
+    print(reader())


### PR DESCRIPTION
## Summary

- marks generated benchmark reports as `linguist-generated=true`
- adds a representative `.lpp` sample
- documents the upstream GitHub Linguist submission checklist
- clarifies in the README that global recognition requires an upstream Linguist PR

## Verification

- `git check-attr linguist-generated` confirms benchmark reports are excluded while hand-authored `.lpp` sources remain detectable.

This PR prepares the L++ repository. A separate contribution to `github-linguist` is still required before GitHub globally recognizes `.lpp` as L++.