### PR TITLE
Migrate and refresh the L++ GitHub Pages website

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,48 @@
+name: Deploy L++ website
+
+on:
+  push:
+    branches: [master]
+    paths:
+      - "website/**"
+      - "assets/**"
+      - ".github/workflows/pages.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+          cache-dependency-path: website/package-lock.json
+      - name: Build website
+        working-directory: website
+        run: |
+          npm ci
+          npm run build
+      - uses: actions/upload-pages-artifact@v3
+        with:
+          path: website/dist
+
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - id: deployment
+        uses: actions/deploy-pages@v4

--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,5 @@ output.c
 /benchmarks/bench.rs
 /benchmarks/bench_pillars.lpp
 /benchmarks/bench_pillars.rs
+/website/node_modules/
+/website/dist/

--- a/website/README.md
+++ b/website/README.md
@@ -1,0 +1,12 @@
+# L++ website source
+
+This is the maintainable React/Vite source for the GitHub Pages site.
+
+```bash
+npm ci
+npm run dev
+npm run build
+```
+
+The deployment workflow publishes `website/dist` to GitHub Pages. The deployed
+`gh-pages` branch is an artifact and should not be edited by hand.

--- a/website/index.html
+++ b/website/index.html
@@ -1,0 +1,17 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="description" content="L++ — a Python-readable, ownership-aware native language with Cranelift AOT, ARC, and a direct Linux ELF linker." />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&family=JetBrains+Mono:ital,wght@0,400;0,500;0,700;1,400&family=Space+Grotesk:wght@400;500;600;700&display=swap" rel="stylesheet" />
+    <link rel="icon" type="image/svg+xml" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 32 32'%3E%3Crect width='32' height='32' rx='7' fill='%23c8f14b'/%3E%3Ctext x='16' y='22' font-family='monospace' font-size='15' font-weight='bold' text-anchor='middle' fill='%23070809'%3EL%2B%2B%3C/text%3E%3C/svg%3E" />
+    <title>L++ — Ownership-aware native language</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -1,0 +1,2622 @@
+{
+  "name": "lpp-website",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "lpp-website",
+      "version": "0.1.0",
+      "dependencies": {
+        "clsx": "2.1.1",
+        "framer-motion": "^12.42.2",
+        "lucide-react": "^1.25.0",
+        "react": "19.2.6",
+        "react-dom": "19.2.6",
+        "tailwind-merge": "3.4.0"
+      },
+      "devDependencies": {
+        "@tailwindcss/vite": "4.1.17",
+        "@types/node": "22.19.17",
+        "@types/react": "19.2.7",
+        "@types/react-dom": "19.2.3",
+        "@vitejs/plugin-react": "5.1.1",
+        "tailwindcss": "4.1.17",
+        "typescript": "5.9.3",
+        "vite": "7.3.2",
+        "vite-plugin-singlefile": "2.3.0"
+      }
+    },
+    "node_modules/@babel/code-frame": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.7.tgz",
+      "integrity": "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-validator-identifier": "^7.29.7",
+        "js-tokens": "^4.0.0",
+        "picocolors": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/compat-data": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.7.tgz",
+      "integrity": "sha512-locTkQyKvwIEgBzVrn8693ebc97F2U8ZHjbXwDXJ5Fn2TCpNwTlKcaKLkdHop5c/icOFE7qt7Q9JC5hnKNa6Gg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/core": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.7.tgz",
+      "integrity": "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.29.7",
+        "@babel/generator": "^7.29.7",
+        "@babel/helper-compilation-targets": "^7.29.7",
+        "@babel/helper-module-transforms": "^7.29.7",
+        "@babel/helpers": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/template": "^7.29.7",
+        "@babel/traverse": "^7.29.7",
+        "@babel/types": "^7.29.7",
+        "@jridgewell/remapping": "^2.3.5",
+        "convert-source-map": "^2.0.0",
+        "debug": "^4.1.0",
+        "gensync": "^1.0.0-beta.2",
+        "json5": "^2.2.3",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/babel"
+      }
+    },
+    "node_modules/@babel/generator": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.7.tgz",
+      "integrity": "sha512-DkXD5OJQaAQIdZ1bt3UZdEnHAn9Imd3IVBdX03UFe+ony9Ojw5pzr9YVKGDY1jt+Gcn/FnGkNf8r+Vj5NOJWtQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.29.7",
+        "@babel/types": "^7.29.7",
+        "@jridgewell/gen-mapping": "^0.3.12",
+        "@jridgewell/trace-mapping": "^0.3.28",
+        "jsesc": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-compilation-targets": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.29.7.tgz",
+      "integrity": "sha512-wem6WaBj4NaVYVdNhLPPVacES6ZJ+KBBfSkTMD3YZxbP3rm3Di85tJU5ljaUNhaOynt+Aj0xruhYuzQBt8n71g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/compat-data": "^7.29.7",
+        "@babel/helper-validator-option": "^7.29.7",
+        "browserslist": "^4.24.0",
+        "lru-cache": "^5.1.1",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-globals": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.29.7.tgz",
+      "integrity": "sha512-3nQVUAtvkKH9zahfWgw96Jc/uFOmjACE1kQz82E2lqWmHBgjzbNlsC22nuQTfahmWeQtTq5nQ/4Nnd2A1wj4zA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-module-imports": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.29.7.tgz",
+      "integrity": "sha512-ejHwrQQYcm9xnTivShn2IDOlIzInN34AXskvq9QicvCtEzq1Vzclu/tKF8Jq1Cg8JG2GL6/EmjgsCT7lXepE3g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/traverse": "^7.29.7",
+        "@babel/types": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-module-transforms": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.29.7.tgz",
+      "integrity": "sha512-UPUVSyXbOh627KiCIGQSgwWzGeBKLkaJ9PJEdrngIwMSzxLR4jS4+f1f1jb7VzBbg8nFLaYotvVPFCTqdrmTAg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-module-imports": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7",
+        "@babel/traverse": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
+      }
+    },
+    "node_modules/@babel/helper-plugin-utils": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.29.7.tgz",
+      "integrity": "sha512-G7sHYigPY17oO5SYWnfD/0MTBwVR781S/JI643e/JhUYgVgWE/61SoW3NH9KWUKyKq5LVh3npif99Wkt6j86Jw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-string-parser": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.29.7.tgz",
+      "integrity": "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
+      "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-option": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.29.7.tgz",
+      "integrity": "sha512-N9ZErrD+yW5geCDtBqnOoxmR8+tNKiGuxKlDpuJxfsqpa2dFcexaziGAE/qoHLiDDreVNMupxGmSoNlyvsA3gw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helpers": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.29.7.tgz",
+      "integrity": "sha512-1k2lAGRMfHTcwuNYcCNUmaUffmQv8KWMfh2iJUUeRlwlwH4FdNG7mfPI10NPfLHJFThE4Tyr4mv7kTNZOiPuBg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/template": "^7.29.7",
+        "@babel/types": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/parser": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.7.tgz",
+      "integrity": "sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.29.7"
+      },
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-react-jsx-self": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-self/-/plugin-transform-react-jsx-self-7.29.7.tgz",
+      "integrity": "sha512-TL0hMc9xzy86VD31nUiwzd5otRAcyEPcsegCxolO0PvcXuH1v0kECe/UIznYFihpkvU5wg/jk4v0TTEFfm53fw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-react-jsx-source": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-source/-/plugin-transform-react-jsx-source-7.29.7.tgz",
+      "integrity": "sha512-06IyK09H3wi4cGbhDBwp5gUGo0IKtnYa8tyTiephirPCK6fbobVGiXMMI5zLQ4aKEYP3wZ3ArU44o+8KMrSG/Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/template": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.29.7.tgz",
+      "integrity": "sha512-puq+Gf35oI24FeN11LkoUQFqv9uwNeWpxXZi/Ji3rRIoKAzKnxRaZ+Gkj0vKS9ZCiTESfng1N9LyOyXvo+m+Gg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/types": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/traverse": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.7.tgz",
+      "integrity": "sha512-EhlfNQtZ+NK22w5BM61ciuiq1m58ed33Wr1Xan//ZRTy6hgjnwyCffRYwzsGXdASJSUJ1guZILsErh1eQcl+zw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.29.7",
+        "@babel/generator": "^7.29.7",
+        "@babel/helper-globals": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/template": "^7.29.7",
+        "@babel/types": "^7.29.7",
+        "debug": "^4.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/types": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.7.tgz",
+      "integrity": "sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-string-parser": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.7.tgz",
+      "integrity": "sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.7.tgz",
+      "integrity": "sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.7.tgz",
+      "integrity": "sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.7.tgz",
+      "integrity": "sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.7.tgz",
+      "integrity": "sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.7.tgz",
+      "integrity": "sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.7.tgz",
+      "integrity": "sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.7.tgz",
+      "integrity": "sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.7.tgz",
+      "integrity": "sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.7.tgz",
+      "integrity": "sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.7.tgz",
+      "integrity": "sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.7.tgz",
+      "integrity": "sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.7.tgz",
+      "integrity": "sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.7.tgz",
+      "integrity": "sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.7.tgz",
+      "integrity": "sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.7.tgz",
+      "integrity": "sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.7.tgz",
+      "integrity": "sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.7.tgz",
+      "integrity": "sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.7.tgz",
+      "integrity": "sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.7.tgz",
+      "integrity": "sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.7.tgz",
+      "integrity": "sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.7.tgz",
+      "integrity": "sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.7.tgz",
+      "integrity": "sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@jridgewell/gen-mapping": {
+      "version": "0.3.13",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
+      "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.0",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/remapping": {
+      "version": "2.3.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/remapping/-/remapping-2.3.5.tgz",
+      "integrity": "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@rolldown/pluginutils": {
+      "version": "1.0.0-beta.47",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-beta.47.tgz",
+      "integrity": "sha512-8QagwMH3kNCuzD8EWL8R2YPW5e4OrHNSAHRFDdmFqEwEaD/KcNKjVoumo+gP2vW5eKB2UPbM6vTYiGZX0ixLnw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.62.2.tgz",
+      "integrity": "sha512-6o7ZLZK+BeenkZCFNDXqpbjw9bD6nuWonvS/lwQJp7NoVVxm6p3qE7qQ5jGuBjiFsgvqjD8mZAU5oWxTmbOeOg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.62.2.tgz",
+      "integrity": "sha512-BaH7BllCACHoH1LguOU56UItGfUWjujlO65kS9LAodViaN4bwIKd7oeW/ZHJ/4ljr/7MIiENnNy3HJ0zXv8Zkw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.62.2.tgz",
+      "integrity": "sha512-v39RCCvj4He82I9sFmk+M1VZ0PLM9sfsLVikjfx2hYBNALhrrOR2D3JjQA6AhlaSOgcR+RzrKY7e1+bT6SUO/A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.62.2.tgz",
+      "integrity": "sha512-yl0y2vq3S3lHeuXhEdss6TWfKW8vkujImO12tn4ZkG/4oghr09LvdYm2RElVjokTQiUvDUGXLGsYeLqUMCKpGA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.62.2.tgz",
+      "integrity": "sha512-tT4pvt4qXD+vEoezupCWi+a1F0vvDiksiHc+PxRlYTOH1I6/X4id9jPxTP+Fg+545euaFT1jJVs4CEdHZAU1vw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.62.2.tgz",
+      "integrity": "sha512-6nU5F2wCW+qvCBhTn1pdIU3bzsIoF7EUwsCDRxilWGprQR6yd508YnH9+OKFCwpfS8pjZqDUmnCAr7exax0XCg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.62.2.tgz",
+      "integrity": "sha512-n1GJHPOvpIfhi3TmrCeh6S6URt9BFCt0KQE3qvexyGCTAKpR4Lg+eWvNZEqu7epxwus/8ElT3hacYEucm49SZg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.62.2.tgz",
+      "integrity": "sha512-JqgflS8wEB+UXV/vS1RpRbifGBeN4D5lz8D8oOFbFZw4vedvdOgCFAjfBmIMdW3yL10XpQQ0Ambepw6MXrhOnA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.62.2.tgz",
+      "integrity": "sha512-wnFJkogWvN4jm/hQRF2UBaeUmk20j5+DmHvoyWii2b8HJDyvz1MF2OU/6ynXt2KR63rbZLWkFpoytpdc/yBuSA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.62.2.tgz",
+      "integrity": "sha512-HVu2bp0zhvJ8xHEV9+UUs7S90VadmBSY3LcIMvozbPo4AuMGDWlz3ymHLHZPX4hR67TKTt8Qp5PJ5RBg/i+RMQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.62.2.tgz",
+      "integrity": "sha512-mQqqAV8QaoSgr9I2fKDLY2BAVvmKjWoGiu/cSYQonsLvtqwEn1E4QYfnCOcp5zoEqNhsDYin1s6jx/VJmrxlZg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.62.2.tgz",
+      "integrity": "sha512-IxKLoxCQ2IWi6bT2akyDUBGsOImDKB+sPp4EsTmwFQ/fMwpCKm8uLSSgP/Kx/QYUgKis6SEZ5/Nlhup0DIA0PQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.62.2.tgz",
+      "integrity": "sha512-Mk5ha2RQSgyFfmYYLkBpPnUk8D8FriBxesO1u9O75X0mHgXL1UQcH5Itl2lurWL2tj0RxV9b9tJgipac0hRY9A==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.62.2.tgz",
+      "integrity": "sha512-CjvEnqJL/0/TQ3TXX3OPIJ/kmBellrWd4heXUmHeJlTnmwjKpSJzoehLaL6Xk0ZnMHBu9dZuFADNOrtjF4v+2w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.62.2.tgz",
+      "integrity": "sha512-1SiZbzwdkaDURsew/tSOrooKiYy7EQGT6m8ufavAi9NEyQb/6VuIxFXAL1fqa4iZe3g4NbNk4P7J32z2tw5Mgg==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.62.2.tgz",
+      "integrity": "sha512-nQts12zJ3NQRoE6uYljOH89v7szzLDvG2JD/vsX+vGXU8w/At1GowTZ5/7qeFQ8m7L55rpR8Okugnuo5bgjy2Q==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.62.2.tgz",
+      "integrity": "sha512-E9/ll019jhPIJgpzfZoIkBGhcz+kKNgVWYRY0zr9srBdPPFVpvOKW8VaJKUbeK+eZXyQF9ltME+Kk6affeaPgg==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.62.2.tgz",
+      "integrity": "sha512-5BqxR/pshjey51iliyzTD5Xi3EN0aLmQ2lZ3lvefVV9c82BvrLo2/6OT55iifpWBufs6kdwWbuOKS841DrmK9A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.62.2.tgz",
+      "integrity": "sha512-uNN83XxQrRAh/w0/pmAfibcwyb6YWt4gP+dpnQKPVJshAloQ785ii8CT8ZCIxkGg9opVsvAlGhFitSm6D1Jjpg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.62.2.tgz",
+      "integrity": "sha512-srjEIxSH3LRnJN6THczDHWQplqEMFiAJrTab0msUryh9kwNpkICf3Ea6q6MN/2cZwRFUNx5w+h6Hpi4QuHS6Zg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.62.2.tgz",
+      "integrity": "sha512-8hOJnxgbyObnCm5AlRA3A931xX19xq80RjVTKgJOvEKWqJruP/Uf12IbAOaDjjEXYRewwHLfmF0YRIdK3OwKWA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.62.2.tgz",
+      "integrity": "sha512-mmF4AY1i0hG/bLWUctUq59gtmgaSIRa3cu/A3JFRp/sCNEme2bgDEiDS22P9FbnJB8NJNF4jPJiSP5RHQpUTDg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.62.2.tgz",
+      "integrity": "sha512-DZgkknc6jhHrk46V25vbAM0zZkyP0nSDkJB8/dRkLTxv470dOmWDqGoEJl/9A0dFfS7yE3REOwNDxpHwSLSt0Q==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.62.2.tgz",
+      "integrity": "sha512-T6xr6ucWSFto+VGajA8YH26LdpHRuP4YLHEKAtCWvJDOlnmWcDZVCI2Jmjr+IFHDlt2zRaTAKE4tfjTaWLgJBg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.62.2.tgz",
+      "integrity": "sha512-BfzEnDJOt9T8M989/lA37EcJgat01wLRnoi5dQf3QzOH7jzpqTAzdDbVfRljVr5r+jzKqpbHeyOfAaXxAd0PAA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@tailwindcss/node": {
+      "version": "4.1.17",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/node/-/node-4.1.17.tgz",
+      "integrity": "sha512-csIkHIgLb3JisEFQ0vxr2Y57GUNYh447C8xzwj89U/8fdW8LhProdxvnVH6U8M2Y73QKiTIH+LWbK3V2BBZsAg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/remapping": "^2.3.4",
+        "enhanced-resolve": "^5.18.3",
+        "jiti": "^2.6.1",
+        "lightningcss": "1.30.2",
+        "magic-string": "^0.30.21",
+        "source-map-js": "^1.2.1",
+        "tailwindcss": "4.1.17"
+      }
+    },
+    "node_modules/@tailwindcss/oxide": {
+      "version": "4.1.17",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide/-/oxide-4.1.17.tgz",
+      "integrity": "sha512-F0F7d01fmkQhsTjXezGBLdrl1KresJTcI3DB8EkScCldyKp3Msz4hub4uyYaVnk88BAS1g5DQjjF6F5qczheLA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10"
+      },
+      "optionalDependencies": {
+        "@tailwindcss/oxide-android-arm64": "4.1.17",
+        "@tailwindcss/oxide-darwin-arm64": "4.1.17",
+        "@tailwindcss/oxide-darwin-x64": "4.1.17",
+        "@tailwindcss/oxide-freebsd-x64": "4.1.17",
+        "@tailwindcss/oxide-linux-arm-gnueabihf": "4.1.17",
+        "@tailwindcss/oxide-linux-arm64-gnu": "4.1.17",
+        "@tailwindcss/oxide-linux-arm64-musl": "4.1.17",
+        "@tailwindcss/oxide-linux-x64-gnu": "4.1.17",
+        "@tailwindcss/oxide-linux-x64-musl": "4.1.17",
+        "@tailwindcss/oxide-wasm32-wasi": "4.1.17",
+        "@tailwindcss/oxide-win32-arm64-msvc": "4.1.17",
+        "@tailwindcss/oxide-win32-x64-msvc": "4.1.17"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-android-arm64": {
+      "version": "4.1.17",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-android-arm64/-/oxide-android-arm64-4.1.17.tgz",
+      "integrity": "sha512-BMqpkJHgOZ5z78qqiGE6ZIRExyaHyuxjgrJ6eBO5+hfrfGkuya0lYfw8fRHG77gdTjWkNWEEm+qeG2cDMxArLQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-darwin-arm64": {
+      "version": "4.1.17",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-darwin-arm64/-/oxide-darwin-arm64-4.1.17.tgz",
+      "integrity": "sha512-EquyumkQweUBNk1zGEU/wfZo2qkp/nQKRZM8bUYO0J+Lums5+wl2CcG1f9BgAjn/u9pJzdYddHWBiFXJTcxmOg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-darwin-x64": {
+      "version": "4.1.17",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-darwin-x64/-/oxide-darwin-x64-4.1.17.tgz",
+      "integrity": "sha512-gdhEPLzke2Pog8s12oADwYu0IAw04Y2tlmgVzIN0+046ytcgx8uZmCzEg4VcQh+AHKiS7xaL8kGo/QTiNEGRog==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-freebsd-x64": {
+      "version": "4.1.17",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-freebsd-x64/-/oxide-freebsd-x64-4.1.17.tgz",
+      "integrity": "sha512-hxGS81KskMxML9DXsaXT1H0DyA+ZBIbyG/sSAjWNe2EDl7TkPOBI42GBV3u38itzGUOmFfCzk1iAjDXds8Oh0g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-linux-arm-gnueabihf": {
+      "version": "4.1.17",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm-gnueabihf/-/oxide-linux-arm-gnueabihf-4.1.17.tgz",
+      "integrity": "sha512-k7jWk5E3ldAdw0cNglhjSgv501u7yrMf8oeZ0cElhxU6Y2o7f8yqelOp3fhf7evjIS6ujTI3U8pKUXV2I4iXHQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-linux-arm64-gnu": {
+      "version": "4.1.17",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm64-gnu/-/oxide-linux-arm64-gnu-4.1.17.tgz",
+      "integrity": "sha512-HVDOm/mxK6+TbARwdW17WrgDYEGzmoYayrCgmLEw7FxTPLcp/glBisuyWkFz/jb7ZfiAXAXUACfyItn+nTgsdQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-linux-arm64-musl": {
+      "version": "4.1.17",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm64-musl/-/oxide-linux-arm64-musl-4.1.17.tgz",
+      "integrity": "sha512-HvZLfGr42i5anKtIeQzxdkw/wPqIbpeZqe7vd3V9vI3RQxe3xU1fLjss0TjyhxWcBaipk7NYwSrwTwK1hJARMg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-linux-x64-gnu": {
+      "version": "4.1.17",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-x64-gnu/-/oxide-linux-x64-gnu-4.1.17.tgz",
+      "integrity": "sha512-M3XZuORCGB7VPOEDH+nzpJ21XPvK5PyjlkSFkFziNHGLc5d6g3di2McAAblmaSUNl8IOmzYwLx9NsE7bplNkwQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-linux-x64-musl": {
+      "version": "4.1.17",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-x64-musl/-/oxide-linux-x64-musl-4.1.17.tgz",
+      "integrity": "sha512-k7f+pf9eXLEey4pBlw+8dgfJHY4PZ5qOUFDyNf7SI6lHjQ9Zt7+NcscjpwdCEbYi6FI5c2KDTDWyf2iHcCSyyQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi": {
+      "version": "4.1.17",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-wasm32-wasi/-/oxide-wasm32-wasi-4.1.17.tgz",
+      "integrity": "sha512-cEytGqSSoy7zK4JRWiTCx43FsKP/zGr0CsuMawhH67ONlH+T79VteQeJQRO/X7L0juEUA8ZyuYikcRBf0vsxhg==",
+      "bundleDependencies": [
+        "@napi-rs/wasm-runtime",
+        "@emnapi/core",
+        "@emnapi/runtime",
+        "@tybys/wasm-util",
+        "@emnapi/wasi-threads",
+        "tslib"
+      ],
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "^1.6.0",
+        "@emnapi/runtime": "^1.6.0",
+        "@emnapi/wasi-threads": "^1.1.0",
+        "@napi-rs/wasm-runtime": "^1.0.7",
+        "@tybys/wasm-util": "^0.10.1",
+        "tslib": "^2.4.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-win32-arm64-msvc": {
+      "version": "4.1.17",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-arm64-msvc/-/oxide-win32-arm64-msvc-4.1.17.tgz",
+      "integrity": "sha512-JU5AHr7gKbZlOGvMdb4722/0aYbU+tN6lv1kONx0JK2cGsh7g148zVWLM0IKR3NeKLv+L90chBVYcJ8uJWbC9A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-win32-x64-msvc": {
+      "version": "4.1.17",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-x64-msvc/-/oxide-win32-x64-msvc-4.1.17.tgz",
+      "integrity": "sha512-SKWM4waLuqx0IH+FMDUw6R66Hu4OuTALFgnleKbqhgGU30DY20NORZMZUKgLRjQXNN2TLzKvh48QXTig4h4bGw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@tailwindcss/vite": {
+      "version": "4.1.17",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/vite/-/vite-4.1.17.tgz",
+      "integrity": "sha512-4+9w8ZHOiGnpcGI6z1TVVfWaX/koK7fKeSYF3qlYg2xpBtbteP2ddBxiarL+HVgfSJGeK5RIxRQmKm4rTJJAwA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@tailwindcss/node": "4.1.17",
+        "@tailwindcss/oxide": "4.1.17",
+        "tailwindcss": "4.1.17"
+      },
+      "peerDependencies": {
+        "vite": "^5.2.0 || ^6 || ^7"
+      }
+    },
+    "node_modules/@types/babel__core": {
+      "version": "7.20.5",
+      "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
+      "integrity": "sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.20.7",
+        "@babel/types": "^7.20.7",
+        "@types/babel__generator": "*",
+        "@types/babel__template": "*",
+        "@types/babel__traverse": "*"
+      }
+    },
+    "node_modules/@types/babel__generator": {
+      "version": "7.27.0",
+      "resolved": "https://registry.npmjs.org/@types/babel__generator/-/babel__generator-7.27.0.tgz",
+      "integrity": "sha512-ufFd2Xi92OAVPYsy+P4n7/U7e68fex0+Ee8gSG9KX7eo084CWiQ4sdxktvdl0bOPupXtVJPY19zk6EwWqUQ8lg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.0.0"
+      }
+    },
+    "node_modules/@types/babel__template": {
+      "version": "7.4.4",
+      "resolved": "https://registry.npmjs.org/@types/babel__template/-/babel__template-7.4.4.tgz",
+      "integrity": "sha512-h/NUaSyG5EyxBIp8YRxo4RMe2/qQgvyowRwVMzhYhBCONbW8PUsg4lkFMrhgZhUe5z3L3MiLDuvyJ/CaPa2A8A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.1.0",
+        "@babel/types": "^7.0.0"
+      }
+    },
+    "node_modules/@types/babel__traverse": {
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.28.0.tgz",
+      "integrity": "sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.28.2"
+      }
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "22.19.17",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.17.tgz",
+      "integrity": "sha512-wGdMcf+vPYM6jikpS/qhg6WiqSV/OhG+jeeHT/KlVqxYfD40iYJf9/AE1uQxVWFvU7MipKRkRv8NSHiCGgPr8Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@types/react": {
+      "version": "19.2.7",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.7.tgz",
+      "integrity": "sha512-MWtvHrGZLFttgeEj28VXHxpmwYbor/ATPYbBfSFZEIRK0ecCFLl2Qo55z52Hss+UV9CRN7trSeq1zbgx7YDWWg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "csstype": "^3.2.2"
+      }
+    },
+    "node_modules/@types/react-dom": {
+      "version": "19.2.3",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.2.3.tgz",
+      "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "^19.2.0"
+      }
+    },
+    "node_modules/@vitejs/plugin-react": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-5.1.1.tgz",
+      "integrity": "sha512-WQfkSw0QbQ5aJ2CHYw23ZGkqnRwqKHD/KYsMeTkZzPT4Jcf0DcBxBtwMJxnu6E7oxw5+JC6ZAiePgh28uJ1HBA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/core": "^7.28.5",
+        "@babel/plugin-transform-react-jsx-self": "^7.27.1",
+        "@babel/plugin-transform-react-jsx-source": "^7.27.1",
+        "@rolldown/pluginutils": "1.0.0-beta.47",
+        "@types/babel__core": "^7.20.5",
+        "react-refresh": "^0.18.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "peerDependencies": {
+        "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0"
+      }
+    },
+    "node_modules/baseline-browser-mapping": {
+      "version": "2.10.43",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.43.tgz",
+      "integrity": "sha512-AjYpR78kDWAY3Efj+cDTFH9t9SCoL7OoTp1BOb0mQV7S+6CiLwnWM3FyxhJtdPufDFKzmCSFoUncKjWgJEZTCQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "baseline-browser-mapping": "dist/cli.cjs"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/braces": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
+      "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fill-range": "^7.1.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/browserslist": {
+      "version": "4.28.6",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.6.tgz",
+      "integrity": "sha512-FQBYNK15VMslhLHpA7+n+n1GOlF1kId2xcCg7/j95f24AOF6VDYMNH4mFxF7KuaTdv627faazpOAjFzMrfJOUw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "baseline-browser-mapping": "^2.10.42",
+        "caniuse-lite": "^1.0.30001803",
+        "electron-to-chromium": "^1.5.389",
+        "node-releases": "^2.0.51",
+        "update-browserslist-db": "^1.2.3"
+      },
+      "bin": {
+        "browserslist": "cli.js"
+      },
+      "engines": {
+        "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
+      }
+    },
+    "node_modules/caniuse-lite": {
+      "version": "1.0.30001806",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001806.tgz",
+      "integrity": "sha512-72Cuvd95zbSYPKq6Fhg8eDJRlzgWDf7/mtoZv6Qe/DYNCEBdNxoA3+rZAU2ZhGCpZlns3EssFavaZomckT5Uuw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "CC-BY-4.0"
+    },
+    "node_modules/clsx": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/csstype": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
+      "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/electron-to-chromium": {
+      "version": "1.5.393",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.393.tgz",
+      "integrity": "sha512-kiDJdIUawuEIcp9XoICKp1iTYDEbgguIPq526N1Q7jIQDeQ3CqoMx71025PI/7E48Ddtw2HuWsVjY7afEgNxmg==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/enhanced-resolve": {
+      "version": "5.24.2",
+      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.24.2.tgz",
+      "integrity": "sha512-rpsZEGT1jFuve6QlpyRp9ckQ+kN61hvF9BzCPyMdaKTm8UJce96KBn3sorXOFXlzjPrs3Vc4T1NsSroZ3PxlFw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.2.4",
+        "tapable": "^2.3.3"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.7.tgz",
+      "integrity": "sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.27.7",
+        "@esbuild/android-arm": "0.27.7",
+        "@esbuild/android-arm64": "0.27.7",
+        "@esbuild/android-x64": "0.27.7",
+        "@esbuild/darwin-arm64": "0.27.7",
+        "@esbuild/darwin-x64": "0.27.7",
+        "@esbuild/freebsd-arm64": "0.27.7",
+        "@esbuild/freebsd-x64": "0.27.7",
+        "@esbuild/linux-arm": "0.27.7",
+        "@esbuild/linux-arm64": "0.27.7",
+        "@esbuild/linux-ia32": "0.27.7",
+        "@esbuild/linux-loong64": "0.27.7",
+        "@esbuild/linux-mips64el": "0.27.7",
+        "@esbuild/linux-ppc64": "0.27.7",
+        "@esbuild/linux-riscv64": "0.27.7",
+        "@esbuild/linux-s390x": "0.27.7",
+        "@esbuild/linux-x64": "0.27.7",
+        "@esbuild/netbsd-arm64": "0.27.7",
+        "@esbuild/netbsd-x64": "0.27.7",
+        "@esbuild/openbsd-arm64": "0.27.7",
+        "@esbuild/openbsd-x64": "0.27.7",
+        "@esbuild/openharmony-arm64": "0.27.7",
+        "@esbuild/sunos-x64": "0.27.7",
+        "@esbuild/win32-arm64": "0.27.7",
+        "@esbuild/win32-ia32": "0.27.7",
+        "@esbuild/win32-x64": "0.27.7"
+      }
+    },
+    "node_modules/escalade": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/fill-range": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
+      "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "to-regex-range": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/framer-motion": {
+      "version": "12.42.2",
+      "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-12.42.2.tgz",
+      "integrity": "sha512-5XY9luDiu0oHfHBjpDthFMh0ES+122w6p/papSJBweMkO8Sn+PW2QaEgRblQBpWFnuvZS5qvarpt/hO2pjGmnw==",
+      "license": "MIT",
+      "dependencies": {
+        "motion-dom": "^12.42.2",
+        "motion-utils": "^12.39.0",
+        "tslib": "^2.4.0"
+      },
+      "peerDependencies": {
+        "@emotion/is-prop-valid": "*",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@emotion/is-prop-valid": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/gensync": {
+      "version": "1.0.0-beta.2",
+      "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
+      "integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/graceful-fs": {
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/is-number": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+      "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.12.0"
+      }
+    },
+    "node_modules/jiti": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.7.0.tgz",
+      "integrity": "sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "jiti": "lib/jiti-cli.mjs"
+      }
+    },
+    "node_modules/js-tokens": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/jsesc": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
+      "integrity": "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "jsesc": "bin/jsesc"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/json5": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+      "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "json5": "lib/cli.js"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/lightningcss": {
+      "version": "1.30.2",
+      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.30.2.tgz",
+      "integrity": "sha512-utfs7Pr5uJyyvDETitgsaqSyjCb2qNRAtuqUeWIAKztsOYdcACf2KtARYXg2pSvhkt+9NfoaNY7fxjl6nuMjIQ==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "dependencies": {
+        "detect-libc": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      },
+      "optionalDependencies": {
+        "lightningcss-android-arm64": "1.30.2",
+        "lightningcss-darwin-arm64": "1.30.2",
+        "lightningcss-darwin-x64": "1.30.2",
+        "lightningcss-freebsd-x64": "1.30.2",
+        "lightningcss-linux-arm-gnueabihf": "1.30.2",
+        "lightningcss-linux-arm64-gnu": "1.30.2",
+        "lightningcss-linux-arm64-musl": "1.30.2",
+        "lightningcss-linux-x64-gnu": "1.30.2",
+        "lightningcss-linux-x64-musl": "1.30.2",
+        "lightningcss-win32-arm64-msvc": "1.30.2",
+        "lightningcss-win32-x64-msvc": "1.30.2"
+      }
+    },
+    "node_modules/lightningcss-android-arm64": {
+      "version": "1.30.2",
+      "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.30.2.tgz",
+      "integrity": "sha512-BH9sEdOCahSgmkVhBLeU7Hc9DWeZ1Eb6wNS6Da8igvUwAe0sqROHddIlvU06q3WyXVEOYDZ6ykBZQnjTbmo4+A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-arm64": {
+      "version": "1.30.2",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.30.2.tgz",
+      "integrity": "sha512-ylTcDJBN3Hp21TdhRT5zBOIi73P6/W0qwvlFEk22fkdXchtNTOU4Qc37SkzV+EKYxLouZ6M4LG9NfZ1qkhhBWA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-x64": {
+      "version": "1.30.2",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.30.2.tgz",
+      "integrity": "sha512-oBZgKchomuDYxr7ilwLcyms6BCyLn0z8J0+ZZmfpjwg9fRVZIR5/GMXd7r9RH94iDhld3UmSjBM6nXWM2TfZTQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-freebsd-x64": {
+      "version": "1.30.2",
+      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.30.2.tgz",
+      "integrity": "sha512-c2bH6xTrf4BDpK8MoGG4Bd6zAMZDAXS569UxCAGcA7IKbHNMlhGQ89eRmvpIUGfKWNVdbhSbkQaWhEoMGmGslA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm-gnueabihf": {
+      "version": "1.30.2",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.30.2.tgz",
+      "integrity": "sha512-eVdpxh4wYcm0PofJIZVuYuLiqBIakQ9uFZmipf6LF/HRj5Bgm0eb3qL/mr1smyXIS1twwOxNWndd8z0E374hiA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-gnu": {
+      "version": "1.30.2",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.30.2.tgz",
+      "integrity": "sha512-UK65WJAbwIJbiBFXpxrbTNArtfuznvxAJw4Q2ZGlU8kPeDIWEX1dg3rn2veBVUylA2Ezg89ktszWbaQnxD/e3A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-musl": {
+      "version": "1.30.2",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.30.2.tgz",
+      "integrity": "sha512-5Vh9dGeblpTxWHpOx8iauV02popZDsCYMPIgiuw97OJ5uaDsL86cnqSFs5LZkG3ghHoX5isLgWzMs+eD1YzrnA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-gnu": {
+      "version": "1.30.2",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.30.2.tgz",
+      "integrity": "sha512-Cfd46gdmj1vQ+lR6VRTTadNHu6ALuw2pKR9lYq4FnhvgBc4zWY1EtZcAc6EffShbb1MFrIPfLDXD6Xprbnni4w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-musl": {
+      "version": "1.30.2",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.30.2.tgz",
+      "integrity": "sha512-XJaLUUFXb6/QG2lGIW6aIk6jKdtjtcffUT0NKvIqhSBY3hh9Ch+1LCeH80dR9q9LBjG3ewbDjnumefsLsP6aiA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-arm64-msvc": {
+      "version": "1.30.2",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.30.2.tgz",
+      "integrity": "sha512-FZn+vaj7zLv//D/192WFFVA0RgHawIcHqLX9xuWiQt7P0PtdFEVaxgF9rjM/IRYHQXNnk61/H/gb2Ei+kUQ4xQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-x64-msvc": {
+      "version": "1.30.2",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.30.2.tgz",
+      "integrity": "sha512-5g1yc73p+iAkid5phb4oVFMB45417DkRevRbt/El/gKXJk4jid+vPFF/AXbxn05Aky8PapwzZrdJShv5C0avjw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lru-cache": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
+      "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/lucide-react": {
+      "version": "1.25.0",
+      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-1.25.0.tgz",
+      "integrity": "sha512-/mdJTRbiwcLOQ1NZZK1amZF9rIZyvO18D6r9TngE6TG1NmqHgFuT4eE7Xrkm9UsXMbBJD1NlfwHVltCDWHrOTw==",
+      "license": "ISC",
+      "peerDependencies": {
+        "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/micromatch": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
+      "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "braces": "^3.0.3",
+        "picomatch": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=8.6"
+      }
+    },
+    "node_modules/micromatch/node_modules/picomatch": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/motion-dom": {
+      "version": "12.42.2",
+      "resolved": "https://registry.npmjs.org/motion-dom/-/motion-dom-12.42.2.tgz",
+      "integrity": "sha512-5gIMWLp/PycBtJRJWRgjxke5n8dlvkSn2DrYW+tr3XcqAZY1xZh6BJyooJXCM8wdfM7wfMjkBJNLge1CKPUIRA==",
+      "license": "MIT",
+      "dependencies": {
+        "motion-utils": "^12.39.0"
+      }
+    },
+    "node_modules/motion-utils": {
+      "version": "12.39.0",
+      "resolved": "https://registry.npmjs.org/motion-utils/-/motion-utils-12.39.0.tgz",
+      "integrity": "sha512-8nadJAJjTtqRkmRF36FoJTrywK9nnFmnPwnSMyxaOCU7GDjN9RTMJIxx9De8ErM+vpPhMccr/6fo5WciyQLnMQ==",
+      "license": "MIT"
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.16",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
+      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/node-releases": {
+      "version": "2.0.51",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.51.tgz",
+      "integrity": "sha512-wRNIrw4DmVLKQlbgOMdkMx27Wrpzes2hh5Jtbi2bjPd+4wJstWIqP5A+lscnqbm0xxmT5Bpg8Lec5ItEBwx6BQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/picomatch": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+      "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.19",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.19.tgz",
+      "integrity": "sha512-Mz8SaolMd8nB+G13WkORcxQKHZ/NE4xXevtkJHVuG+guo9/wYKlIMTKAqGdEmYOXR2ijPjTYNHssizdaVSUNdQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.12",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/react": {
+      "version": "19.2.6",
+      "resolved": "https://registry.npmjs.org/react/-/react-19.2.6.tgz",
+      "integrity": "sha512-sfWGGfavi0xr8Pg0sVsyHMAOziVYKgPLNrS7ig+ivMNb3wbCBw3KxtflsGBAwD3gYQlE/AEZsTLgToRrSCjb0Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-dom": {
+      "version": "19.2.6",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.6.tgz",
+      "integrity": "sha512-0prMI+hvBbPjsWnxDLxlCGyM8PN6UuWjEUCYmZhO67xIV9Xasa/r/vDnq+Xyq4Lo27g8QSbO5YzARu0D1Sps3g==",
+      "license": "MIT",
+      "dependencies": {
+        "scheduler": "^0.27.0"
+      },
+      "peerDependencies": {
+        "react": "^19.2.6"
+      }
+    },
+    "node_modules/react-refresh": {
+      "version": "0.18.0",
+      "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.18.0.tgz",
+      "integrity": "sha512-QgT5//D3jfjJb6Gsjxv0Slpj23ip+HtOpnNgnb2S5zU3CB26G/IDPGoy4RJB42wzFE46DRsstbW6tKHoKbhAxw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/rollup": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.62.2.tgz",
+      "integrity": "sha512-RFnrW4lhXA3s3eqHDZvN654g8OTjzRfqpIRJYczCGB6HzphckVAi/Qh4tbPUbRuDi7s1Llv8g/NspLkttY3gTA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "1.0.9"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-android-arm-eabi": "4.62.2",
+        "@rollup/rollup-android-arm64": "4.62.2",
+        "@rollup/rollup-darwin-arm64": "4.62.2",
+        "@rollup/rollup-darwin-x64": "4.62.2",
+        "@rollup/rollup-freebsd-arm64": "4.62.2",
+        "@rollup/rollup-freebsd-x64": "4.62.2",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.62.2",
+        "@rollup/rollup-linux-arm-musleabihf": "4.62.2",
+        "@rollup/rollup-linux-arm64-gnu": "4.62.2",
+        "@rollup/rollup-linux-arm64-musl": "4.62.2",
+        "@rollup/rollup-linux-loong64-gnu": "4.62.2",
+        "@rollup/rollup-linux-loong64-musl": "4.62.2",
+        "@rollup/rollup-linux-ppc64-gnu": "4.62.2",
+        "@rollup/rollup-linux-ppc64-musl": "4.62.2",
+        "@rollup/rollup-linux-riscv64-gnu": "4.62.2",
+        "@rollup/rollup-linux-riscv64-musl": "4.62.2",
+        "@rollup/rollup-linux-s390x-gnu": "4.62.2",
+        "@rollup/rollup-linux-x64-gnu": "4.62.2",
+        "@rollup/rollup-linux-x64-musl": "4.62.2",
+        "@rollup/rollup-openbsd-x64": "4.62.2",
+        "@rollup/rollup-openharmony-arm64": "4.62.2",
+        "@rollup/rollup-win32-arm64-msvc": "4.62.2",
+        "@rollup/rollup-win32-ia32-msvc": "4.62.2",
+        "@rollup/rollup-win32-x64-gnu": "4.62.2",
+        "@rollup/rollup-win32-x64-msvc": "4.62.2",
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/scheduler": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
+      "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
+      "license": "MIT"
+    },
+    "node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/tailwind-merge": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/tailwind-merge/-/tailwind-merge-3.4.0.tgz",
+      "integrity": "sha512-uSaO4gnW+b3Y2aWoWfFpX62vn2sR3skfhbjsEnaBI81WD1wBLlHZe5sWf0AqjksNdYTbGBEd0UasQMT3SNV15g==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/dcastil"
+      }
+    },
+    "node_modules/tailwindcss": {
+      "version": "4.1.17",
+      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.1.17.tgz",
+      "integrity": "sha512-j9Ee2YjuQqYT9bbRTfTZht9W/ytp5H+jJpZKiYdP/bpnXARAuELt9ofP0lPnmHjbga7SNQIxdTAXCmtKVYjN+Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tapable": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.3.3.tgz",
+      "integrity": "sha512-uxc/zpqFg6x7C8vOE7lh6Lbda8eEL9zmVm/PLeTPBRhh1xCgdWaQ+J1CUieGpIfm2HdtsUpRv+HshiasBMcc6A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/webpack"
+      }
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.17",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
+      "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/to-regex-range": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+      "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-number": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=8.0"
+      }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/update-browserslist-db": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz",
+      "integrity": "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "escalade": "^3.2.0",
+        "picocolors": "^1.1.1"
+      },
+      "bin": {
+        "update-browserslist-db": "cli.js"
+      },
+      "peerDependencies": {
+        "browserslist": ">= 4.21.0"
+      }
+    },
+    "node_modules/vite": {
+      "version": "7.3.2",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.2.tgz",
+      "integrity": "sha512-Bby3NOsna2jsjfLVOHKes8sGwgl4TT0E6vvpYgnAYDIF/tie7MRaFthmKuHx1NSXjiTueXH3do80FMQgvEktRg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.27.0",
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.3",
+        "postcss": "^8.5.6",
+        "rollup": "^4.43.0",
+        "tinyglobby": "^0.2.15"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^20.19.0 || >=22.12.0",
+        "jiti": ">=1.21.0",
+        "less": "^4.0.0",
+        "lightningcss": "^1.21.0",
+        "sass": "^1.70.0",
+        "sass-embedded": "^1.70.0",
+        "stylus": ">=0.54.8",
+        "sugarss": "^5.0.0",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite-plugin-singlefile": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/vite-plugin-singlefile/-/vite-plugin-singlefile-2.3.0.tgz",
+      "integrity": "sha512-DAcHzYypM0CasNLSz/WG0VdKOCxGHErfrjOoyIPiNxTPTGmO6rRD/te93n1YL/s+miXq66ipF1brMBikf99c6A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "micromatch": "^4.0.8"
+      },
+      "engines": {
+        "node": ">18.0.0"
+      },
+      "peerDependencies": {
+        "rollup": "^4.44.1",
+        "vite": "^5.4.11 || ^6.0.0 || ^7.0.0"
+      }
+    },
+    "node_modules/yallist": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
+      "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
+      "dev": true,
+      "license": "ISC"
+    }
+  }
+}

--- a/website/package.json
+++ b/website/package.json
@@ -1,0 +1,31 @@
+{
+  "name": "lpp-website",
+  "private": true,
+  "version": "0.1.0",
+  "description": "Source for the L++ GitHub Pages website.",
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "clsx": "2.1.1",
+    "framer-motion": "^12.42.2",
+    "lucide-react": "^1.25.0",
+    "react": "19.2.6",
+    "react-dom": "19.2.6",
+    "tailwind-merge": "3.4.0"
+  },
+  "devDependencies": {
+    "@tailwindcss/vite": "4.1.17",
+    "@types/node": "22.19.17",
+    "@types/react": "19.2.7",
+    "@types/react-dom": "19.2.3",
+    "@vitejs/plugin-react": "5.1.1",
+    "tailwindcss": "4.1.17",
+    "typescript": "5.9.3",
+    "vite": "7.3.2",
+    "vite-plugin-singlefile": "2.3.0"
+  }
+}

--- a/website/public/install.ps1
+++ b/website/public/install.ps1
@@ -1,0 +1,71 @@
+<#
+.SYNOPSIS
+    Installs the L++ compiler and runtime assets to a per-user directory.
+
+.DESCRIPTION
+    Builds the release compiler, copies `lpp.exe` and `lpp_runtime.c` into
+    `$HOME\.lpp`, and optionally precompiles `lpp_runtime.obj` when MSVC is
+    available. The installed `lpp.exe` is the primary CLI entrypoint.
+
+.EXAMPLE
+    .\install.ps1
+#>
+
+$ErrorActionPreference = "Stop"
+
+$ProjectDir = $PSScriptRoot
+$InstallDir = if ($env:LPP_INSTALL_DIR) { $env:LPP_INSTALL_DIR } else { Join-Path $HOME ".lpp" }
+$BinDir = Join-Path $InstallDir "bin"
+$LibDir = Join-Path $InstallDir "lib"
+$CompilerSource = Join-Path $ProjectDir "target\release\lpp.exe"
+$CompilerDest = Join-Path $BinDir "lpp.exe"
+$RuntimeSource = Join-Path $ProjectDir "lpp_runtime.c"
+$RuntimeObject = Join-Path $LibDir "lpp_runtime.obj"
+
+Write-Host "========================================================" -ForegroundColor Cyan
+Write-Host "                 L++ GLOBAL INSTALLER                   " -ForegroundColor Cyan
+Write-Host "========================================================" -ForegroundColor Cyan
+
+Write-Host "`n[1/4] Building release compiler and linker MVP..." -ForegroundColor Yellow
+$proc = Start-Process -FilePath "cargo" -ArgumentList "build --release --bin lpp --bin lpp-link" -WorkingDirectory $ProjectDir -NoNewWindow -Wait -PassThru
+if ($proc.ExitCode -ne 0) {
+    Write-Error "Cargo build failed. Make sure Rust is installed and cargo is on PATH."
+    exit 1
+}
+
+Write-Host "`n[2/4] Preparing install directories..." -ForegroundColor Yellow
+New-Item -ItemType Directory -Force $BinDir | Out-Null
+New-Item -ItemType Directory -Force $LibDir | Out-Null
+
+Write-Host "`n[3/4] Installing compiler and runtime files..." -ForegroundColor Yellow
+Copy-Item -Path $CompilerSource -Destination $CompilerDest -Force
+$LinkerSource = Join-Path $ProjectDir "target\release\lpp-link.exe"
+if (Test-Path $LinkerSource) {
+    Copy-Item -Path $LinkerSource -Destination (Join-Path $BinDir "lpp-link.exe") -Force
+}
+Copy-Item -Path $RuntimeSource -Destination (Join-Path $LibDir "lpp_runtime.c") -Force
+
+if (Get-Command cl.exe -ErrorAction SilentlyContinue) {
+    Write-Host "  Precompiling runtime object with cl.exe..." -ForegroundColor Yellow
+    & cl.exe /nologo /O2 /c (Join-Path $LibDir "lpp_runtime.c") "/Fo:$RuntimeObject" 2>&1 | Out-Null
+} else {
+    Write-Host "  MSVC not detected. Native builds will compile lpp_runtime.c at link time." -ForegroundColor DarkYellow
+}
+
+Write-Host "`n[4/4] Updating PATH guidance..." -ForegroundColor Yellow
+$registryKey = [Microsoft.Win32.Registry]::CurrentUser.OpenSubKey("Environment", $true)
+$currentPath = $registryKey.GetValue("Path", "", [Microsoft.Win32.RegistryValueOptions]::DoNotExpandEnvironmentNames)
+
+if ($currentPath -split ";" -notcontains $BinDir) {
+    $newPath = ($currentPath + ";" + $BinDir) -replace ";+", ";"
+    $registryKey.SetValue("Path", $newPath, [Microsoft.Win32.RegistryValueKind]::String)
+    Write-Host "  Added $BinDir to Current User PATH." -ForegroundColor Green
+    Write-Host "  Restart your terminal to pick up the PATH change." -ForegroundColor Green
+} else {
+    Write-Host "  $BinDir is already present in Current User PATH." -ForegroundColor Green
+}
+$registryKey.Close()
+
+Write-Host "`n========================================================" -ForegroundColor Green
+Write-Host "       L++ INSTALLED. TRY: lpp.exe -h OR lpp -h         " -ForegroundColor Green
+Write-Host "========================================================" -ForegroundColor Green

--- a/website/public/install.sh
+++ b/website/public/install.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env sh
+set -eu
+
+PROJECT_DIR=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+INSTALL_DIR=${LPP_INSTALL_DIR:-"$HOME/.lpp"}
+BIN_DIR="$INSTALL_DIR/bin"
+LIB_DIR="$INSTALL_DIR/lib"
+
+printf '%s\n' "========================================================"
+printf '%s\n' "                 L++ GLOBAL INSTALLER                   "
+printf '%s\n' "========================================================"
+
+printf '\n%s\n' "[1/4] Building release compiler and ELF linker MVP..."
+(cd "$PROJECT_DIR" && cargo build --release --bin lpp --bin lpp-link)
+
+printf '\n%s\n' "[2/4] Preparing install directories..."
+mkdir -p "$BIN_DIR" "$LIB_DIR"
+
+printf '\n%s\n' "[3/4] Installing compiler and runtime files..."
+cp "$PROJECT_DIR/target/release/lpp" "$BIN_DIR/lpp"
+if [ -f "$PROJECT_DIR/target/release/lpp-link" ]; then
+    cp "$PROJECT_DIR/target/release/lpp-link" "$BIN_DIR/lpp-link"
+fi
+cp "$PROJECT_DIR/lpp_runtime.c" "$LIB_DIR/lpp_runtime.c"
+
+if command -v cc >/dev/null 2>&1; then
+    printf '%s\n' "  Packaging prebuilt runtime object with cc..."
+    cc -O2 -fPIC -c "$LIB_DIR/lpp_runtime.c" -o "$LIB_DIR/lpp_runtime.o"
+    cc -O2 -ffreestanding -fno-stack-protector -fno-pic -mno-red-zone \
+        -c "$PROJECT_DIR/runtime/linux_x86_64_min.c" -o "$LIB_DIR/lpp_runtime_min.o" || true
+    printf '%s\n' "  Normal lpp builds will link this object without recompiling lpp_runtime.c."
+else
+    printf '%s\n' "  cc not found: runtime source fallback will be used by native builds."
+fi
+
+printf '\n%s\n' "[4/4] PATH guidance..."
+printf '%s\n' "  Add this to your shell profile if needed:"
+printf '  export PATH="%s:$PATH"\n' "$BIN_DIR"
+
+printf '\n%s\n' "========================================================"
+printf '%s\n' "             L++ INSTALLED. TRY: lpp -h                 "
+printf '%s\n' "========================================================"

--- a/website/public/lpp-icon-16.svg
+++ b/website/public/lpp-icon-16.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" role="img" aria-label="L++ icon">
+  <rect width="16" height="16" rx="3" fill="#101a35"/>
+  <path d="M8 1.5 13 4.4v5.2L8 14.5 3 11.6V4.4Z" fill="none" stroke="#7dcbff" stroke-width=".7"/>
+  <path d="M5.3 5.2v5h2.6M10 6.3h2M11 5.3v2M12.5 6.3h1.5M13.25 5.55v1.5" fill="none" stroke="#fff" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.15"/>
+</svg>

--- a/website/public/lpp-logo.svg
+++ b/website/public/lpp-logo.svg
@@ -1,0 +1,29 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512" role="img" aria-labelledby="title desc">
+  <title id="title">L++ logo</title>
+  <desc id="desc">A four-pillar prism surrounding the L++ mark.</desc>
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#101a35"/>
+      <stop offset="1" stop-color="#172a52"/>
+    </linearGradient>
+    <linearGradient id="prism" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#69d8ff"/>
+      <stop offset=".48" stop-color="#8b7bff"/>
+      <stop offset="1" stop-color="#57f0b4"/>
+    </linearGradient>
+    <filter id="glow" x="-40%" y="-40%" width="180%" height="180%">
+      <feGaussianBlur stdDeviation="8" result="blur"/>
+      <feMerge><feMergeNode in="blur"/><feMergeNode in="SourceGraphic"/></feMerge>
+    </filter>
+  </defs>
+  <rect width="512" height="512" rx="104" fill="url(#bg)"/>
+  <path d="M256 67 406 154v174L256 415 106 328V154Z" fill="none" stroke="#35527f" stroke-width="12"/>
+  <path d="M256 67v348M106 154l300 174M406 154 106 328" fill="none" stroke="#35527f" stroke-width="8" opacity=".65"/>
+  <path d="M256 103 374 171v136L256 375 138 307V171Z" fill="#0d1630" stroke="url(#prism)" stroke-width="12" filter="url(#glow)"/>
+  <path d="M256 103v272M138 171l236 136M374 171 138 307" fill="none" stroke="url(#prism)" stroke-width="7" opacity=".85"/>
+  <path d="M190 203v108h58" fill="none" stroke="#f7fbff" stroke-linecap="round" stroke-linejoin="round" stroke-width="24"/>
+  <path d="M286 226h52M312 200v52M350 226h40M370 206v40" fill="none" stroke="#f7fbff" stroke-linecap="round" stroke-width="16"/>
+  <circle cx="256" cy="103" r="10" fill="#69d8ff"/>
+  <circle cx="138" cy="307" r="10" fill="#8b7bff"/>
+  <circle cx="374" cy="307" r="10" fill="#57f0b4"/>
+</svg>

--- a/website/src/App.tsx
+++ b/website/src/App.tsx
@@ -1,0 +1,31 @@
+import Nav from "./components/Nav";
+import Hero from "./components/Hero";
+import Marquee from "./components/Marquee";
+import Pillars from "./components/Pillars";
+import MemoryModel from "./components/MemoryModel";
+import Showcase from "./components/Showcase";
+import Performance from "./components/Performance";
+import Stdlib from "./components/Stdlib";
+import Roadmap from "./components/Roadmap";
+import Install from "./components/Install";
+import Footer from "./components/Footer";
+
+export default function App() {
+  return (
+    <div className="noise relative min-h-screen bg-ink font-sans text-white antialiased">
+      <Nav />
+      <main>
+        <Hero />
+        <Marquee />
+        <Pillars />
+        <MemoryModel />
+        <Showcase />
+        <Performance />
+        <Stdlib />
+        <Roadmap />
+        <Install />
+      </main>
+      <Footer />
+    </div>
+  );
+}

--- a/website/src/components/Footer.tsx
+++ b/website/src/components/Footer.tsx
@@ -1,0 +1,102 @@
+import { ArrowUpRight } from "lucide-react";
+
+const COLS = [
+  {
+    title: "Language",
+    links: [
+      { label: "Syntax basics", href: "#syntax" },
+      { label: "Memory model", href: "#memory" },
+      { label: "Escape rules", href: "#memory" },
+      { label: "Standard library", href: "#stdlib" },
+    ],
+  },
+  {
+    title: "Compiler",
+    links: [
+      { label: "Performance", href: "#performance" },
+      { label: "Cranelift AOT", href: "#performance" },
+      { label: "C transpiler", href: "#performance" },
+      { label: "Roadmap", href: "#roadmap" },
+    ],
+  },
+  {
+    title: "Start",
+    links: [
+      { label: "Install", href: "#install" },
+      { label: "lpp -h", href: "#install" },
+      { label: "Back to top", href: "#top" },
+    ],
+  },
+];
+
+export default function Footer() {
+  return (
+    <footer className="relative overflow-hidden border-t border-white/[0.07]">
+      <div className="relative mx-auto max-w-7xl px-5 pb-10 pt-20 md:px-8">
+        <div className="grid gap-12 md:grid-cols-[1.2fr_1.8fr]">
+          <div>
+            <a href="#top" className="flex w-max items-center gap-3">
+              <span className="grid h-10 w-10 place-items-center rounded-lg bg-acid font-mono text-base font-bold text-ink">
+                L++
+              </span>
+              <span className="font-mono text-[11px] leading-tight text-white/40">
+                the hybrid memory
+                <br />
+                language
+              </span>
+            </a>
+            <p className="mt-6 max-w-sm text-[14.5px] leading-relaxed text-white/40">
+              An experimental prototype proving that memory management can be a compiler's job —
+              not a programmer's burden, not a runtime's tax.
+            </p>
+            <a
+              href="#install"
+              className="group mt-7 inline-flex items-center gap-2 rounded-xl border border-acid/30 bg-acid/[0.06] px-5 py-3 font-mono text-[12.5px] text-acid transition-all hover:bg-acid hover:text-ink"
+            >
+              Build something fast
+              <ArrowUpRight className="h-4 w-4 transition-transform group-hover:translate-x-0.5 group-hover:-translate-y-0.5" />
+            </a>
+          </div>
+
+          <div className="grid grid-cols-2 gap-8 sm:grid-cols-3">
+            {COLS.map((c) => (
+              <div key={c.title}>
+                <p className="font-mono text-[10px] uppercase tracking-[0.25em] text-white/30">
+                  {c.title}
+                </p>
+                <ul className="mt-4 space-y-2.5">
+                  {c.links.map((l) => (
+                    <li key={l.label}>
+                      <a
+                        href={l.href}
+                        className="text-[13.5px] text-white/50 transition-colors hover:text-acid"
+                      >
+                        {l.label}
+                      </a>
+                    </li>
+                  ))}
+                </ul>
+              </div>
+            ))}
+          </div>
+        </div>
+
+        <div className="mt-16 flex flex-col items-start justify-between gap-4 border-t border-white/[0.07] pt-7 font-mono text-[11px] text-white/30 sm:flex-row sm:items-center">
+          <span>© 2026 the L++ project — experimental prototype</span>
+          <span>
+            no garbage collectors were harmed <span className="text-acid">++</span> no borrow
+            checkers either
+          </span>
+        </div>
+      </div>
+
+      {/* giant watermark */}
+      <div
+        aria-hidden
+        className="pointer-events-none select-none text-center font-mono text-[26vw] font-bold leading-[0.72] tracking-tighter text-white/[0.025]"
+      >
+        L++
+      </div>
+    </footer>
+  );
+}

--- a/website/src/components/Hero.tsx
+++ b/website/src/components/Hero.tsx
@@ -1,0 +1,226 @@
+import { useEffect, useRef, useState } from "react";
+import { motion, useScroll, useTransform } from "framer-motion";
+import { ArrowDown, Cpu, Layers, Network, Boxes, Terminal } from "lucide-react";
+import { Code } from "../lib/highlight";
+import { EASE } from "../lib/ui";
+
+const SNIPPETS = [
+  `def fib(n: Int) -> Int:
+    if n < 2:
+        return n
+    return fib(n - 1) + fib(n - 2)
+
+def main():
+    result := fib(35)   # verified through lpp-link
+    print(result)`,
+  `struct Item:
+    value: Int
+
+def create_item() -> Item:
+    item := Item()
+    return item   # escapes -> Managed Heap
+                  # no Box, no Rc, no &`,
+  `def identity(value: Item) -> Item:
+    return value       # borrowed → retained → ReturnOwned
+
+def main():
+    original := Item()
+    returned := identity(original)`,
+];
+
+function useTypewriter() {
+  const [idx, setIdx] = useState(0);
+  const [len, setLen] = useState(0);
+  useEffect(() => {
+    const full = SNIPPETS[idx];
+    if (len < full.length) {
+      const ch = full[len];
+      const delay = ch === "\n" ? 90 : 14 + Math.random() * 26;
+      const t = setTimeout(() => setLen((l) => l + 1), delay);
+      return () => clearTimeout(t);
+    }
+    const t = setTimeout(() => {
+      setLen(0);
+      setIdx((i) => (i + 1) % SNIPPETS.length);
+    }, 4600);
+    return () => clearTimeout(t);
+  }, [len, idx]);
+  return SNIPPETS[idx].slice(0, len);
+}
+
+const HUD_ROWS = [
+  { icon: Layers, name: "result", kind: "Int · scalar", target: "Stack", color: "text-acid", bg: "bg-acid", border: "border-acid/30" },
+  { icon: Boxes, name: "item", kind: "struct · escapes", target: "Managed Heap", color: "text-lav", bg: "bg-lav", border: "border-lav/30" },
+  { icon: Network, name: "node", kind: "self-referential", target: "Arena", color: "text-aqua", bg: "bg-aqua", border: "border-aqua/30" },
+];
+
+export default function Hero() {
+  const typed = useTypewriter();
+  const ref = useRef<HTMLDivElement>(null);
+  const { scrollYProgress } = useScroll({ target: ref, offset: ["start start", "end start"] });
+  const codeY = useTransform(scrollYProgress, [0, 1], [0, 110]);
+  const hudY = useTransform(scrollYProgress, [0, 1], [0, 60]);
+  const fade = useTransform(scrollYProgress, [0, 0.7], [1, 0]);
+
+  return (
+    <section ref={ref} id="top" className="relative overflow-hidden pt-[72px]">
+      {/* glows */}
+      <div className="pointer-events-none absolute -top-40 left-1/2 h-[560px] w-[900px] -translate-x-1/2 rounded-full bg-acid/[0.07] blur-[130px]" />
+      <div className="pointer-events-none absolute -right-40 top-1/3 h-[420px] w-[420px] rounded-full bg-lav/[0.06] blur-[120px]" />
+      <div className="absolute inset-0 bg-grid [mask-image:radial-gradient(ellipse_75%_65%_at_50%_0%,black,transparent)]" />
+
+      <motion.div style={{ opacity: fade }} className="relative mx-auto max-w-7xl px-5 pb-16 pt-16 md:px-8 md:pt-24 lg:pb-24">
+        <div className="grid items-center gap-14 lg:grid-cols-[1.05fr_0.95fr]">
+          {/* left — headline */}
+          <div>
+            <motion.div
+              initial={{ opacity: 0, y: 20 }}
+              animate={{ opacity: 1, y: 0 }}
+              transition={{ duration: 0.8, ease: EASE, delay: 0.25 }}
+              className="mb-7 inline-flex items-center gap-2.5 rounded-full border border-white/10 bg-white/[0.03] py-1.5 pl-2 pr-4"
+            >
+              <span className="flex items-center gap-1.5 rounded-full bg-acid/15 px-2.5 py-0.5 font-mono text-[10px] font-semibold uppercase tracking-wider text-acid">
+                <span className="h-1.5 w-1.5 rounded-full bg-acid animate-pulse-dot" />
+                v0.1 prototype
+              </span>
+              <span className="font-mono text-[11px] text-white/50">Cranelift AOT backend is live</span>
+            </motion.div>
+
+            <h1 className="font-display text-[clamp(2.9rem,7.2vw,5.6rem)] font-bold leading-[0.98] tracking-[-0.03em] text-white">
+              {["Readable by default.", "Native when verified.", "Ownership-aware by design."].map((line, i) => (
+                <span key={i} className="block overflow-hidden">
+                  <motion.span
+                    initial={{ y: "110%" }}
+                    animate={{ y: 0 }}
+                    transition={{ duration: 1, ease: EASE, delay: 0.35 + i * 0.13 }}
+                    className={`block ${i === 1 ? "text-acid" : ""} ${i === 2 ? "text-outline" : ""}`}
+                  >
+                    {line}
+                  </motion.span>
+                </span>
+              ))}
+            </h1>
+
+            <motion.p
+              initial={{ opacity: 0, y: 20 }}
+              animate={{ opacity: 1, y: 0 }}
+              transition={{ duration: 0.9, ease: EASE, delay: 0.8 }}
+              className="mt-7 max-w-xl text-lg leading-relaxed text-white/55"
+            >
+              L++ is an experimental native language with an{" "}
+              <span className="text-white">ownership-aware compiler pipeline</span> — escape
+              analysis and MIR decide when values borrow, move, retain, release, or return ownership.{" "}
+              Unsupported lifetime cases are rejected instead of silently compiled.
+            </motion.p>
+
+            <motion.div
+              initial={{ opacity: 0, y: 20 }}
+              animate={{ opacity: 1, y: 0 }}
+              transition={{ duration: 0.9, ease: EASE, delay: 0.95 }}
+              className="mt-9 flex flex-wrap items-center gap-4"
+            >
+              <a
+                href="#install"
+                className="group flex items-center gap-2.5 rounded-xl bg-acid px-6 py-3.5 font-mono text-sm font-semibold text-ink transition-all duration-300 hover:brightness-110 glow-acid"
+              >
+                <Terminal className="h-4 w-4" />
+                Install the compiler
+              </a>
+              <a
+                href="#memory"
+                className="group flex items-center gap-2.5 rounded-xl border border-white/12 bg-white/[0.03] px-6 py-3.5 font-mono text-sm text-white/80 transition-all duration-300 hover:border-acid/40 hover:text-acid"
+              >
+                <Cpu className="h-4 w-4" />
+                See the memory magic
+              </a>
+            </motion.div>
+
+            <motion.div
+              initial={{ opacity: 0 }}
+              animate={{ opacity: 1 }}
+              transition={{ duration: 1, delay: 1.2 }}
+              className="mt-10 flex flex-wrap gap-x-8 gap-y-3 font-mono text-[11px] uppercase tracking-[0.18em] text-white/35"
+            >
+              <span>King20 20 / 20 direct</span>
+              <span>~1.6 ms direct link</span>
+              <span>ARC + closures + lists</span>
+              <span>Linux ELF · Windows COFF W1</span>
+            </motion.div>
+          </div>
+
+          {/* right — code window + HUD */}
+          <motion.div
+            initial={{ opacity: 0, y: 40, rotate: 1.5 }}
+            animate={{ opacity: 1, y: 0, rotate: 0 }}
+            transition={{ duration: 1.1, ease: EASE, delay: 0.55 }}
+            className="relative"
+          >
+            <motion.div style={{ y: codeY }} className="relative">
+              <div className="overflow-hidden rounded-2xl border border-white/10 bg-panel/90 shadow-[0_40px_100px_-20px_rgb(0_0_0/0.9)] backdrop-blur">
+                <div className="flex items-center gap-2 border-b border-white/[0.07] bg-white/[0.025] px-4 py-3">
+                  <span className="h-2.5 w-2.5 rounded-full bg-[#ff5f57]" />
+                  <span className="h-2.5 w-2.5 rounded-full bg-[#febc2e]" />
+                  <span className="h-2.5 w-2.5 rounded-full bg-[#28c840]" />
+                  <span className="ml-3 font-mono text-[11px] text-white/40">hello.lpp</span>
+                  <span className="ml-auto flex items-center gap-1.5 font-mono text-[10px] text-acid/80">
+                    <span className="h-1.5 w-1.5 rounded-full bg-acid animate-pulse-dot" />
+                    lpp --watch
+                  </span>
+                </div>
+                <pre className="code-scroll min-h-[300px] overflow-x-auto p-5 font-mono text-[12.5px] leading-[1.8] md:min-h-[320px] md:text-[13px]">
+                  <code className="whitespace-pre">
+                    <Code src={typed} />
+                    <span className="ml-0.5 inline-block h-[15px] w-[8px] translate-y-[3px] bg-acid animate-blink" />
+                  </code>
+                </pre>
+              </div>
+
+              {/* floating HUD */}
+              <motion.div
+                style={{ y: hudY }}
+                className="relative z-10 mx-4 -mt-8 rounded-2xl border border-white/10 bg-panel2/95 p-4 shadow-[0_30px_70px_-15px_rgb(0_0_0/0.9)] backdrop-blur-xl md:mx-0 md:-ml-10 md:mr-6"
+              >
+                <div className="mb-3 flex items-center justify-between">
+                  <span className="font-mono text-[10px] uppercase tracking-[0.22em] text-white/40">
+                    escape analysis · side table
+                  </span>
+                  <span className="font-mono text-[10px] text-acid">0.4 ms</span>
+                </div>
+                <div className="space-y-2">
+                  {HUD_ROWS.map((r, i) => (
+                    <motion.div
+                      key={r.name}
+                      initial={{ opacity: 0, x: 24 }}
+                      animate={{ opacity: 1, x: 0 }}
+                      transition={{ duration: 0.7, ease: EASE, delay: 1.15 + i * 0.18 }}
+                      className={`flex items-center gap-3 rounded-xl border ${r.border} bg-white/[0.02] px-3 py-2.5`}
+                    >
+                      <r.icon className={`h-4 w-4 shrink-0 ${r.color}`} />
+                      <span className="font-mono text-[12px] text-white/85">{r.name}</span>
+                      <span className="hidden font-mono text-[10px] text-white/35 sm:block">{r.kind}</span>
+                      <span className="ml-auto flex items-center gap-1.5 font-mono text-[10px] font-semibold">
+                        <span className={`h-1.5 w-1.5 rounded-full ${r.bg}`} />
+                        <span className={r.color}>{r.target}</span>
+                      </span>
+                    </motion.div>
+                  ))}
+                </div>
+              </motion.div>
+            </motion.div>
+          </motion.div>
+        </div>
+
+        <motion.a
+          href="#language"
+          initial={{ opacity: 0 }}
+          animate={{ opacity: 1 }}
+          transition={{ delay: 1.8, duration: 1 }}
+          className="mt-16 hidden w-max items-center gap-2 font-mono text-[11px] uppercase tracking-[0.25em] text-white/30 transition-colors hover:text-acid lg:flex"
+        >
+          <ArrowDown className="h-3.5 w-3.5 animate-bounce" />
+          scroll to explore
+        </motion.a>
+      </motion.div>
+    </section>
+  );
+}

--- a/website/src/components/Install.tsx
+++ b/website/src/components/Install.tsx
@@ -1,0 +1,169 @@
+import { useState } from "react";
+import { AnimatePresence, motion } from "framer-motion";
+import { Copy, Check, TerminalSquare, Hammer, FolderGit2, Play } from "lucide-react";
+import { SectionHead, Reveal, EASE } from "../lib/ui";
+
+const TABS = [
+  {
+    id: "windows",
+    label: "Windows (PowerShell)",
+    copy: "irm https://samarnever-droid.github.io/lplusplus/install.ps1 | iex",
+    lines: [
+      { p: "PS>", t: "irm https://samarnever-droid.github.io/lplusplus/install.ps1 | iex", c: "text-white" },
+      { p: "", t: "  downloading lpp.exe ................... ok", c: "text-white/45" },
+      { p: "", t: "  downloading lpp_runtime.c ............. ok", c: "text-white/45" },
+      { p: "", t: "  precompiling lpp_runtime.obj .......... ok", c: "text-white/45" },
+      { p: "", t: "  path adding ~/.lpp/bin to PATH ........ ok", c: "text-white/45" },
+      { p: "", t: "", c: "" },
+      { p: "PS>", t: "lpp -h", c: "text-white" },
+      { p: "", t: "L++ Compiler v0.1.0", c: "text-acid" },
+    ],
+  },
+  {
+    id: "unix",
+    label: "macOS / Linux",
+    copy: "curl -sSfL https://samarnever-droid.github.io/lplusplus/install.sh | sh",
+    lines: [
+      { p: "$", t: "curl -sSfL https://samarnever-droid.github.io/lplusplus/install.sh | sh", c: "text-white" },
+      { p: "", t: "  downloading lpp_runtime.c ............. ok", c: "text-white/45" },
+      { p: "", t: "  compiling lpp from source ............. ok", c: "text-white/45" },
+      { p: "", t: "  precompiling lpp_runtime.o ............ ok", c: "text-white/45" },
+      { p: "", t: "", c: "" },
+      { p: "$", t: "lpp -h", c: "text-white" },
+      { p: "", t: "L++ Compiler v0.1.0", c: "text-acid" },
+    ],
+  },
+];
+
+const STEPS = [
+  {
+    icon: TerminalSquare,
+    title: "Run the installer",
+    body: "Open PowerShell in the project root and execute .\\install.ps1. It builds the release compiler and stages everything under %USERPROFILE%\\.lpp.",
+  },
+  {
+    icon: FolderGit2,
+    title: "Restart your terminal",
+    body: "The installer adds ~/.lpp/bin to your user PATH. Reopen your shell or IDE and the global lpp command is live.",
+  },
+  {
+    icon: Play,
+    title: "Choose file or package mode",
+    body: "Use lpp emit file.lpp for source artifacts, lpp build for packages, or LPP_LINKER=direct lpp build on verified Linux x86-64 projects.",
+  },
+];
+
+export default function Install() {
+  const [tab, setTab] = useState(0);
+  const [copied, setCopied] = useState(false);
+  const current = TABS[tab];
+
+  const doCopy = async () => {
+    try {
+      await navigator.clipboard.writeText(current.copy);
+    } catch {
+      /* clipboard unavailable */
+    }
+    setCopied(true);
+    setTimeout(() => setCopied(false), 1600);
+  };
+
+  return (
+    <section id="install" className="relative border-t border-white/[0.06] py-28 md:py-36">
+      <div className="pointer-events-none absolute bottom-0 left-1/2 h-[420px] w-[900px] -translate-x-1/2 rounded-full bg-acid/[0.06] blur-[140px]" />
+      <div className="relative mx-auto max-w-7xl px-5 md:px-8">
+        <SectionHead
+          index="07"
+          kicker="Zero-friction toolchain"
+          title={
+            <>
+              From clone to native binary{" "}
+              <span className="text-acid">in one command.</span>
+            </>
+          }
+          desc="A premium toolchain wrapper installs the compiler globally: binary, runtime library, CLI shim and PATH wiring — handled for you."
+        />
+
+        <div className="mt-14 grid gap-6 lg:grid-cols-[0.9fr_1.1fr]">
+          <div className="space-y-4">
+            {STEPS.map((s, i) => (
+              <Reveal key={s.title} delay={i * 0.09}>
+                <div className="group flex gap-5 rounded-2xl border border-white/[0.08] bg-panel p-6 transition-colors hover:border-acid/25">
+                  <div className="flex h-11 w-11 shrink-0 items-center justify-center rounded-xl border border-acid/25 bg-acid/[0.07]">
+                    <s.icon className="h-5 w-5 text-acid" />
+                  </div>
+                  <div>
+                    <p className="font-mono text-[10px] text-white/30">step 0{i + 1}</p>
+                    <h3 className="mt-1 font-display text-lg font-semibold tracking-tight text-white">
+                      {s.title}
+                    </h3>
+                    <p className="mt-1.5 text-[14px] leading-relaxed text-white/45">{s.body}</p>
+                  </div>
+                </div>
+              </Reveal>
+            ))}
+          </div>
+
+          <Reveal delay={0.15}>
+            <div className="overflow-hidden rounded-2xl border border-white/10 bg-[#0a0c0f] shadow-[0_40px_90px_-25px_rgb(0_0_0/0.9)]">
+              <div className="flex items-center gap-2 border-b border-white/[0.07] bg-white/[0.025] px-4 py-3">
+                <span className="h-2.5 w-2.5 rounded-full bg-[#ff5f57]" />
+                <span className="h-2.5 w-2.5 rounded-full bg-[#febc2e]" />
+                <span className="h-2.5 w-2.5 rounded-full bg-[#28c840]" />
+                <div className="ml-4 flex gap-1">
+                  {TABS.map((t, i) => (
+                    <button
+                      key={t.id}
+                      onClick={() => setTab(i)}
+                      className={`rounded-md px-3 py-1.5 font-mono text-[11px] transition-colors ${
+                        i === tab ? "bg-acid/15 text-acid" : "text-white/40 hover:text-white/70"
+                      }`}
+                    >
+                      {t.label}
+                    </button>
+                  ))}
+                </div>
+                <button
+                  onClick={doCopy}
+                  className="ml-auto flex items-center gap-1.5 rounded-md border border-white/10 px-2.5 py-1.5 font-mono text-[10.5px] text-white/50 transition-colors hover:border-acid/40 hover:text-acid"
+                >
+                  {copied ? <Check className="h-3 w-3 text-acid" /> : <Copy className="h-3 w-3" />}
+                  {copied ? "copied" : "copy"}
+                </button>
+              </div>
+              <div className="min-h-[380px] p-5 font-mono text-[12.5px] leading-[1.9]">
+                <AnimatePresence mode="wait">
+                  <motion.div
+                    key={current.id}
+                    initial={{ opacity: 0, y: 10 }}
+                    animate={{ opacity: 1, y: 0 }}
+                    exit={{ opacity: 0 }}
+                    transition={{ duration: 0.35, ease: EASE }}
+                  >
+                    {current.lines.map((l, i) => (
+                      <p key={i} className={l.c}>
+                        {l.p && <span className="mr-2 select-none text-lav">{l.p}</span>}
+                        {l.t || "\u00A0"}
+                      </p>
+                    ))}
+                    <p>
+                      <span className="mr-2 select-none text-lav">PS&gt;</span>
+                      <span className="ml-0.5 inline-block h-[14px] w-[8px] translate-y-[2px] bg-acid animate-blink" />
+                    </p>
+                  </motion.div>
+                </AnimatePresence>
+              </div>
+            </div>
+            <div className="mt-4 flex items-center gap-3 rounded-xl border border-white/[0.08] bg-panel px-5 py-4">
+              <Hammer className="h-4 w-4 shrink-0 text-acid" />
+              <p className="font-mono text-[11.5px] leading-relaxed text-white/40">
+                requires Windows + MSVC build tools today — the C transpiler backend targets GCC /
+                Clang toolchains next.
+              </p>
+            </div>
+          </Reveal>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/website/src/components/Marquee.tsx
+++ b/website/src/components/Marquee.tsx
@@ -1,0 +1,37 @@
+const ITEMS = [
+  "no garbage collector",
+  "no borrow checker",
+  "semantic escape analysis",
+  "cranelift aot",
+  "c transpiler",
+  "arena allocation",
+  "arc managed heap",
+  "zero-cost stack values",
+  "3 ms compiles",
+  "native x86-64",
+];
+
+export default function Marquee() {
+  const row = (
+    <>
+      {ITEMS.map((t) => (
+        <span key={t} className="flex shrink-0 items-center gap-6 pr-6">
+          <span className="font-mono text-[13px] uppercase tracking-[0.22em] text-white/60">
+            {t}
+          </span>
+          <span className="font-mono text-[13px] font-bold text-acid">++</span>
+        </span>
+      ))}
+    </>
+  );
+  return (
+    <div className="relative border-y border-white/[0.07] bg-panel/60 py-4">
+      <div className="mask-fade-x overflow-hidden">
+        <div className="flex w-max animate-marquee">
+          {row}
+          {row}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/website/src/components/MemoryModel.tsx
+++ b/website/src/components/MemoryModel.tsx
@@ -1,0 +1,371 @@
+import { useState } from "react";
+import { AnimatePresence, motion } from "framer-motion";
+import { Layers, Boxes, Network, Lock, MoveRight, ScanSearch } from "lucide-react";
+import { SectionHead, Reveal, EASE } from "../lib/ui";
+import { CodeBlock } from "../lib/highlight";
+
+type Target = "stack" | "heap" | "arena";
+
+interface Rule {
+  id: number;
+  title: string;
+  short: string;
+  code: string;
+  highlight: number[];
+  target: Target;
+  varName: string;
+  stayed: string[];
+  verdict: string;
+}
+
+const RULES: Rule[] = [
+  {
+    id: 1,
+    title: "Returned by Reference",
+    short: "A local returned to the caller escapes its stack frame.",
+    code: `struct Item:\n    value: Int\n\ndef create_item() -> Item:\n    item := Item()\n    return item   # escapes its frame`,
+    highlight: [6],
+    target: "heap",
+    varName: "item",
+    stayed: [],
+    verdict:
+      "item outlives its own frame, so the compiler ref-counts it on the Managed Heap. Returning a scalar copy like box.count never triggers this.",
+  },
+  {
+    id: 2,
+    title: "Closure Capture",
+    short: "Captured by a closure that outlives its scope.",
+    code: `def process():\n    multiplier := 5\n    config := Config()\n    callback := fn(x) -> Int:\n        print(config)          # captured\n        return x * multiplier  # cloned by value`,
+    highlight: [5],
+    target: "heap",
+    varName: "config",
+    stayed: ["multiplier"],
+    verdict:
+      "config is captured by an escaping closure → Managed Heap. multiplier is an immutable scalar — cloned by value, stays on the stack for free.",
+  },
+  {
+    id: 3,
+    title: "Unbounded Containers",
+    short: "Stored in a container with a dynamic lifetime.",
+    code: `def build_list() -> Void:\n    cap := 8\n    node := Node()\n    my_list := [node]   # lifetime becomes dynamic`,
+    highlight: [4],
+    target: "heap",
+    varName: "node",
+    stayed: ["cap"],
+    verdict:
+      "A list's lifetime is unbounded — it can grow, shrink, and travel anywhere. Anything stored inside is promoted to the Managed Heap.",
+  },
+  {
+    id: 4,
+    title: "Concurrency Boundary",
+    short: "Captured by a spawn closure crossing a thread.",
+    code: `def parallel_work() -> Void:\n    readonly := 100\n    mut shared := 0\n    spawn fn() -> Void:\n        print(readonly, shared)`,
+    highlight: [4],
+    target: "heap",
+    varName: "shared",
+    stayed: ["readonly"],
+    verdict:
+      "shared is mutable state crossing a thread boundary → Managed Heap for safe sharing. readonly is immutable: copied straight onto the new thread's stack.",
+  },
+  {
+    id: 5,
+    title: "Self-Referential Structs",
+    short: "A struct containing its own type becomes graph-shaped.",
+    code: `struct Node:\n    value: Int\n    next: Node    # type-level cycle\n\ndef main():\n    depth := 0\n    node := Node()`,
+    highlight: [3, 7],
+    target: "arena",
+    varName: "node",
+    stayed: ["depth"],
+    verdict:
+      "Node references its own type — linked lists, trees, graphs. Instances are bulk-allocated in an Arena: one blazing-fast region, freed in a single shot.",
+  },
+];
+
+const ZONES: Record<
+  Target,
+  { icon: typeof Layers; name: string; sub: string; desc: string; text: string; border: string; bg: string; dot: string }
+> = {
+  stack: {
+    icon: Layers,
+    name: "Stack",
+    sub: "Value storage",
+    desc: "zero-cost · frame-bound",
+    text: "text-acid",
+    border: "border-acid/45",
+    bg: "bg-acid/[0.06]",
+    dot: "bg-acid",
+  },
+  heap: {
+    icon: Boxes,
+    name: "Managed Heap",
+    sub: "ARC",
+    desc: "automatic ref-counting",
+    text: "text-lav",
+    border: "border-lav/45",
+    bg: "bg-lav/[0.06]",
+    dot: "bg-lav",
+  },
+  arena: {
+    icon: Network,
+    name: "Arena",
+    sub: "bulk allocator",
+    desc: "graphs · freed in one shot",
+    text: "text-aqua",
+    border: "border-aqua/45",
+    bg: "bg-aqua/[0.06]",
+    dot: "bg-aqua",
+  },
+};
+
+export default function MemoryModel() {
+  const [active, setActive] = useState(0);
+  const rule = RULES[active];
+
+  return (
+    <section id="memory" className="relative border-t border-white/[0.06] py-28 md:py-36">
+      <div className="pointer-events-none absolute left-1/2 top-0 h-[420px] w-[820px] -translate-x-1/2 rounded-full bg-lav/[0.05] blur-[130px]" />
+      <div className="relative mx-auto max-w-7xl px-5 md:px-8">
+        <SectionHead
+          index="02"
+          kicker="The magic — hybrid memory model"
+          title={
+            <>
+              You write code. The compiler{" "}
+              <span className="text-acid">decides where it lives.</span>
+            </>
+          }
+          desc="Every binding starts as a zero-cost stack value. A semantic pass — Escape Analysis — checks five rules and monotonically promotes escaping values to the ARC Managed Heap or an Arena. No Box, no Rc, no &, no *. Ever."
+        />
+
+        {/* promotion ladder */}
+        <Reveal delay={0.1} className="mt-10">
+          <div className="flex flex-wrap items-center gap-x-4 gap-y-3 rounded-2xl border border-white/[0.08] bg-panel px-5 py-4">
+            <span className="font-mono text-[10px] uppercase tracking-[0.25em] text-white/35">
+              promotion ladder
+            </span>
+            <div className="flex flex-wrap items-center gap-x-3 gap-y-2 font-mono text-[12px]">
+              <span className="flex items-center gap-2 rounded-lg border border-acid/30 bg-acid/[0.07] px-3 py-1.5 text-acid">
+                <span className="h-1.5 w-1.5 rounded-full bg-acid" /> Value · stack
+              </span>
+              <MoveRight className="h-4 w-4 text-white/25" />
+              <span className="flex items-center gap-2 rounded-lg border border-lav/30 bg-lav/[0.07] px-3 py-1.5 text-lav">
+                <span className="h-1.5 w-1.5 rounded-full bg-lav" /> Managed Heap · ARC
+              </span>
+              <MoveRight className="h-4 w-4 text-white/25" />
+              <span className="flex items-center gap-2 rounded-lg border border-aqua/30 bg-aqua/[0.07] px-3 py-1.5 text-aqua">
+                <span className="h-1.5 w-1.5 rounded-full bg-aqua" /> Arena · bulk
+              </span>
+              <span className="pl-2 text-[11px] text-white/35">
+                monotonic — a binding never demotes
+              </span>
+            </div>
+          </div>
+        </Reveal>
+
+        {/* rules + code */}
+        <div className="mt-14 grid gap-6 lg:grid-cols-[0.9fr_1.1fr]">
+          <Reveal delay={0.05}>
+            <div className="flex h-full flex-col gap-2.5">
+              {RULES.map((r, i) => (
+                <button
+                  key={r.id}
+                  onClick={() => setActive(i)}
+                  className={`group rounded-xl border p-4 text-left transition-all duration-300 ${
+                    i === active
+                      ? "border-acid/45 bg-acid/[0.06]"
+                      : "border-white/[0.08] bg-panel hover:border-white/20"
+                  }`}
+                >
+                  <div className="flex items-center gap-3">
+                    <span
+                      className={`font-mono text-[11px] ${i === active ? "text-acid" : "text-white/30"}`}
+                    >
+                      R{r.id}
+                    </span>
+                    <span
+                      className={`font-display text-[15px] font-semibold tracking-tight ${
+                        i === active ? "text-white" : "text-white/70"
+                      }`}
+                    >
+                      {r.title}
+                    </span>
+                    <span
+                      className={`ml-auto font-mono text-[10px] uppercase tracking-wider transition-opacity ${
+                        i === active ? "text-acid opacity-100" : "opacity-0"
+                      }`}
+                    >
+                      analyzing
+                    </span>
+                  </div>
+                  <p className="mt-1.5 pl-9 text-[13px] leading-snug text-white/40">{r.short}</p>
+                </button>
+              ))}
+
+              <div className="rounded-xl border border-dashed border-white/[0.12] bg-transparent p-4 opacity-60">
+                <div className="flex items-center gap-3">
+                  <span className="font-mono text-[11px] text-white/30">R6</span>
+                  <span className="font-display text-[15px] font-semibold tracking-tight text-white/50">
+                    Required Aliasing
+                  </span>
+                  <Lock className="ml-auto h-3.5 w-3.5 text-white/30" />
+                </div>
+                <p className="mt-1.5 pl-9 text-[13px] text-white/35">
+                  Reserved — pending future language features.
+                </p>
+              </div>
+            </div>
+          </Reveal>
+
+          <Reveal delay={0.15}>
+            <div className="relative h-full">
+              <AnimatePresence mode="wait">
+                <motion.div
+                  key={rule.id}
+                  initial={{ opacity: 0, x: 26 }}
+                  animate={{ opacity: 1, x: 0 }}
+                  exit={{ opacity: 0, x: -18 }}
+                  transition={{ duration: 0.45, ease: EASE }}
+                  className="relative"
+                >
+                  <CodeBlock
+                    code={rule.code}
+                    title={`rule_${rule.id}.lpp`}
+                    highlight={rule.highlight}
+                    badge="escape analysis"
+                  />
+                  {/* scan sweep */}
+                  <motion.div
+                    key={`scan-${rule.id}`}
+                    initial={{ top: "8%", opacity: 0 }}
+                    animate={{ top: "88%", opacity: [0, 1, 1, 0] }}
+                    transition={{ duration: 1.1, ease: "easeInOut" }}
+                    className="pointer-events-none absolute inset-x-4 h-px bg-gradient-to-r from-transparent via-acid to-transparent"
+                  />
+                </motion.div>
+              </AnimatePresence>
+
+              <div className="mt-4 flex items-start gap-3 rounded-xl border border-white/[0.08] bg-panel p-4">
+                <ScanSearch className="mt-0.5 h-4 w-4 shrink-0 text-acid" />
+                <p className="text-[13.5px] leading-relaxed text-white/55">
+                  <AnimatePresence mode="wait">
+                    <motion.span
+                      key={rule.id}
+                      initial={{ opacity: 0 }}
+                      animate={{ opacity: 1 }}
+                      exit={{ opacity: 0 }}
+                      transition={{ duration: 0.35 }}
+                    >
+                      {rule.verdict}
+                    </motion.span>
+                  </AnimatePresence>
+                </p>
+              </div>
+            </div>
+          </Reveal>
+        </div>
+
+        {/* memory map */}
+        <Reveal delay={0.1} className="mt-8">
+          <div className="overflow-hidden rounded-2xl border border-white/[0.08] bg-panel">
+            <div className="flex flex-wrap items-center justify-between gap-2 border-b border-white/[0.07] bg-white/[0.02] px-5 py-3.5">
+              <span className="font-mono text-[10px] uppercase tracking-[0.25em] text-white/40">
+                runtime memory map — resolved at compile time
+              </span>
+              <span className="font-mono text-[10px] text-white/30">
+                rule {rule.id} · <span className="text-acid">{rule.title.toLowerCase()}</span>
+              </span>
+            </div>
+            <div className="grid md:grid-cols-3">
+              {(Object.keys(ZONES) as Target[]).map((key, zi) => {
+                const z = ZONES[key];
+                const isTarget = rule.target === key;
+                return (
+                  <div
+                    key={key}
+                    className={`relative border-white/[0.07] p-6 transition-colors duration-500 ${
+                      zi < 2 ? "md:border-r" : ""
+                    } ${zi > 0 ? "border-t md:border-t-0" : ""} ${isTarget ? z.bg : ""}`}
+                  >
+                    <div className="flex items-center gap-2.5">
+                      <z.icon className={`h-[18px] w-[18px] ${isTarget ? z.text : "text-white/30"}`} />
+                      <span
+                        className={`font-display text-lg font-semibold tracking-tight ${
+                          isTarget ? "text-white" : "text-white/55"
+                        }`}
+                      >
+                        {z.name}
+                      </span>
+                      <span
+                        className={`rounded border px-1.5 py-0.5 font-mono text-[9px] uppercase tracking-wider ${
+                          isTarget ? `${z.border} ${z.text}` : "border-white/10 text-white/30"
+                        }`}
+                      >
+                        {z.sub}
+                      </span>
+                    </div>
+                    <p className="mt-1 font-mono text-[10.5px] text-white/30">{z.desc}</p>
+
+                    <div className="mt-5 flex min-h-[92px] flex-wrap content-start items-start gap-2">
+                      {key === "stack" &&
+                        rule.stayed.map((s, i) => (
+                          <motion.span
+                            key={`${rule.id}-${s}`}
+                            initial={{ opacity: 0, y: 8 }}
+                            animate={{ opacity: 1, y: 0 }}
+                            transition={{ delay: 0.35 + i * 0.1, duration: 0.5, ease: EASE }}
+                            className="flex items-center gap-1.5 rounded-lg border border-acid/25 bg-acid/[0.05] px-2.5 py-1.5 font-mono text-[11px] text-acid/80"
+                          >
+                            <span className="h-1 w-1 rounded-full bg-acid/60" />
+                            {s}
+                          </motion.span>
+                        ))}
+                      {key === "stack" && rule.stayed.length === 0 && (
+                        <span className="font-mono text-[10.5px] italic text-white/25">
+                          scalar copies stay — nothing to promote
+                        </span>
+                      )}
+                      {isTarget ? (
+                        <motion.span
+                          key={rule.id}
+                          initial={{ opacity: 0, y: -26, scale: 0.6 }}
+                          animate={{ opacity: 1, y: 0, scale: 1 }}
+                          transition={{ type: "spring", stiffness: 300, damping: 20, delay: 0.55 }}
+                          className={`flex items-center gap-2 rounded-lg border ${z.border} ${z.bg} px-3.5 py-2 font-mono text-[12px] font-semibold ${z.text} shadow-[0_0_30px_-6px_currentColor]`}
+                        >
+                            <span className={`h-1.5 w-1.5 rounded-full ${z.dot} animate-pulse-dot`} />
+                          {rule.varName}
+                        </motion.span>
+                      ) : (
+                        key !== "stack" && (
+                          <span className="font-mono text-[10.5px] italic text-white/20">idle</span>
+                        )
+                      )}
+                    </div>
+                  </div>
+                );
+              })}
+            </div>
+            <div className="border-t border-white/[0.07] bg-white/[0.015] px-5 py-3">
+              <AnimatePresence mode="wait">
+                <motion.p
+                  key={rule.id}
+                  initial={{ opacity: 0, y: 6 }}
+                  animate={{ opacity: 1, y: 0 }}
+                  exit={{ opacity: 0 }}
+                  transition={{ duration: 0.4, delay: 0.6 }}
+                  className="font-mono text-[11px] text-white/45"
+                >
+                  <span className="text-white/30">storage verdict → </span>
+                  <span className={ZONES[rule.target].text}>
+                    {rule.varName} : {ZONES[rule.target].name}
+                  </span>
+                  <span className="text-white/30"> · inserted automatically · zero annotations written</span>
+                </motion.p>
+              </AnimatePresence>
+            </div>
+          </div>
+        </Reveal>
+      </div>
+    </section>
+  );
+}

--- a/website/src/components/Nav.tsx
+++ b/website/src/components/Nav.tsx
@@ -1,0 +1,104 @@
+import { useEffect, useState } from "react";
+import { motion } from "framer-motion";
+import { Menu, X, ArrowUpRight } from "lucide-react";
+import { EASE } from "../lib/ui";
+
+const LINKS = [
+  { label: "Language", href: "#language" },
+  { label: "Memory", href: "#memory" },
+  { label: "Syntax", href: "#syntax" },
+  { label: "Speed", href: "#performance" },
+  { label: "Stdlib", href: "#stdlib" },
+  { label: "Roadmap", href: "#roadmap" },
+];
+
+export default function Nav() {
+  const [scrolled, setScrolled] = useState(false);
+  const [open, setOpen] = useState(false);
+
+  useEffect(() => {
+    const fn = () => setScrolled(window.scrollY > 24);
+    fn();
+    window.addEventListener("scroll", fn, { passive: true });
+    return () => window.removeEventListener("scroll", fn);
+  }, []);
+
+  return (
+    <motion.header
+      initial={{ y: -80, opacity: 0 }}
+      animate={{ y: 0, opacity: 1 }}
+      transition={{ duration: 0.9, ease: EASE, delay: 0.15 }}
+      className={`fixed inset-x-0 top-0 z-50 transition-all duration-500 ${
+        scrolled
+          ? "border-b border-white/[0.07] bg-ink/80 backdrop-blur-xl"
+          : "border-b border-transparent bg-transparent"
+      }`}
+    >
+      <nav className="mx-auto flex h-[72px] max-w-7xl items-center justify-between px-5 md:px-8">
+        <a href="#top" className="group flex items-center gap-3">
+          <img
+            src={`${import.meta.env.BASE_URL}lpp-icon-16.svg`}
+            alt="L++"
+            className="h-9 w-9 rounded-lg transition-transform duration-300 group-hover:-rotate-6"
+          />
+          <span className="hidden font-mono text-[11px] leading-tight text-white/40 sm:block">
+            hybrid memory
+            <br />
+            language
+          </span>
+        </a>
+
+        <div className="hidden items-center gap-7 lg:flex">
+          {LINKS.map((l) => (
+            <a
+              key={l.href}
+              href={l.href}
+              className="font-mono text-[12px] uppercase tracking-[0.14em] text-white/55 transition-colors hover:text-acid"
+            >
+              {l.label}
+            </a>
+          ))}
+        </div>
+
+        <div className="flex items-center gap-3">
+          <a
+            href="#install"
+            className="group hidden items-center gap-1.5 rounded-lg bg-acid px-4 py-2 font-mono text-[12px] font-semibold text-ink transition-all hover:brightness-110 sm:flex"
+          >
+            lpp -v
+            <ArrowUpRight className="h-3.5 w-3.5 transition-transform group-hover:translate-x-0.5 group-hover:-translate-y-0.5" />
+          </a>
+          <button
+            onClick={() => setOpen(!open)}
+            className="grid h-9 w-9 place-items-center rounded-lg border border-white/10 text-white/70 lg:hidden"
+            aria-label="menu"
+          >
+            {open ? <X className="h-4 w-4" /> : <Menu className="h-4 w-4" />}
+          </button>
+        </div>
+      </nav>
+
+      {open && (
+        <div className="border-t border-white/[0.07] bg-ink/95 px-5 py-4 backdrop-blur-xl lg:hidden">
+          {LINKS.map((l) => (
+            <a
+              key={l.href}
+              href={l.href}
+              onClick={() => setOpen(false)}
+              className="block py-2.5 font-mono text-sm uppercase tracking-[0.14em] text-white/70 hover:text-acid"
+            >
+              {l.label}
+            </a>
+          ))}
+          <a
+            href="#install"
+            onClick={() => setOpen(false)}
+            className="mt-2 block rounded-lg bg-acid px-4 py-2.5 text-center font-mono text-sm font-semibold text-ink"
+          >
+            Install L++
+          </a>
+        </div>
+      )}
+    </motion.header>
+  );
+}

--- a/website/src/components/Performance.tsx
+++ b/website/src/components/Performance.tsx
@@ -1,0 +1,167 @@
+import { useEffect, useRef, useState } from "react";
+import { animate, motion, useInView } from "framer-motion";
+import { Timer, Package, Gauge, GitBranch } from "lucide-react";
+import { SectionHead, Reveal, EASE } from "../lib/ui";
+
+function Counter({
+  to,
+  decimals = 0,
+  suffix = "",
+  prefix = "",
+}: {
+  to: number;
+  decimals?: number;
+  suffix?: string;
+  prefix?: string;
+}) {
+  const ref = useRef<HTMLSpanElement>(null);
+  const inView = useInView(ref, { once: true, margin: "-60px" });
+  const [val, setVal] = useState(0);
+  useEffect(() => {
+    if (!inView) return;
+    const c = animate(0, to, {
+      duration: 1.8,
+      ease: EASE,
+      onUpdate: (v) => setVal(v),
+    });
+    return () => c.stop();
+  }, [inView, to]);
+  return (
+    <span ref={ref}>
+      {prefix}
+      {val.toFixed(decimals)}
+      {suffix}
+    </span>
+  );
+}
+
+const BENCH = [
+  { name: "Host final link", ms: 200, label: "~200 ms", color: "bg-white/15", text: "text-white/40", note: "fallback path" },
+  { name: "L++ direct ELF link", ms: 1.7, label: "~1.7 ms", color: "bg-acid", text: "text-acid", note: "King20 direct", glow: true },
+  { name: "100k escape analysis", ms: 691, label: "691 ms", color: "bg-lav", text: "text-lav", note: "scalability target" },
+  { name: "100k Cranelift AOT", ms: 634, label: "634 ms", color: "bg-aqua", text: "text-aqua", note: "scalability target" },
+];
+
+const STATS = [
+  { icon: Timer, value: <Counter to={1.7} decimals={1} suffix=" ms" />, label: "direct ELF link", sub: "King20 Linux x86-64 path" },
+  { icon: Gauge, value: <Counter to={20} suffix=" / 20" />, label: "direct linker gate", sub: "King20 Stable verified" },
+  { icon: Package, value: <Counter to={100} suffix="k LOC" />, label: "scalability workload", sub: "phase timings recorded" },
+  { icon: GitBranch, value: <Counter to={4} />, label: "toolchain paths", sub: "AOT · C fallback · ELF · COFF W1" },
+];
+
+export default function Performance() {
+  const chartRef = useRef<HTMLDivElement>(null);
+  const inView = useInView(chartRef, { once: true, margin: "-100px" });
+  const max = Math.sqrt(1280);
+
+  return (
+    <section id="performance" className="relative border-t border-white/[0.06] py-28 md:py-36">
+      <div className="pointer-events-none absolute -left-32 top-1/3 h-[420px] w-[420px] rounded-full bg-acid/[0.05] blur-[130px]" />
+      <div className="relative mx-auto max-w-7xl px-5 md:px-8">
+        <SectionHead
+          index="04"
+          kicker="Measured, not promised"
+          title={
+            <>
+              Native speed, <span className="text-acid">measured in milliseconds.</span>
+            </>
+          }
+          desc="L++ measures every phase: parsing, ownership analysis, MIR, Cranelift, and linking. Direct ELF removes the host final-link bottleneck for the verified Linux subset."
+        />
+
+        <div className="mt-14 grid gap-6 lg:grid-cols-[1.05fr_0.95fr]">
+          {/* benchmark chart */}
+          <Reveal>
+            <div ref={chartRef} className="flex h-full flex-col rounded-2xl border border-white/[0.08] bg-panel p-7">
+              <div className="mb-8 flex items-center justify-between">
+                <span className="font-mono text-[10px] uppercase tracking-[0.25em] text-white/40">
+                  recursive fib(35) — wall time
+                </span>
+                <span className="font-mono text-[10px] text-white/25">√ scale · lower is better</span>
+              </div>
+              <div className="flex flex-1 flex-col justify-center gap-6">
+                {BENCH.map((b, i) => (
+                  <div key={b.name}>
+                    <div className="mb-2 flex items-baseline justify-between font-mono text-[12px]">
+                      <span className={b.glow ? "font-semibold text-white" : "text-white/55"}>
+                        {b.name}
+                        <span className="ml-2 text-[10px] uppercase tracking-wider text-white/25">{b.note}</span>
+                      </span>
+                      <span className={`font-semibold ${b.text}`}>{b.label}</span>
+                    </div>
+                    <div className="h-3 overflow-hidden rounded-full bg-white/[0.05]">
+                      <motion.div
+                        initial={{ width: 0 }}
+                        animate={inView ? { width: `${Math.max((Math.sqrt(b.ms) / max) * 100, 6)}%` } : {}}
+                        transition={{ duration: 1.4, delay: 0.15 + i * 0.12, ease: EASE }}
+                        className={`h-full rounded-full ${b.color} ${b.glow ? "glow-acid" : ""}`}
+                      />
+                    </div>
+                  </div>
+                ))}
+              </div>
+              <p className="mt-8 border-t border-white/[0.06] pt-4 font-mono text-[11px] leading-relaxed text-white/30">
+                L++ matches optimized C within noise while compiling the whole program before
+                Python finishes importing.
+              </p>
+            </div>
+          </Reveal>
+
+          {/* pipeline card */}
+          <Reveal delay={0.12}>
+            <div className="flex h-full flex-col rounded-2xl border border-white/[0.08] bg-panel p-7">
+              <span className="font-mono text-[10px] uppercase tracking-[0.25em] text-white/40">
+                compilation pipeline
+              </span>
+              <div className="mt-6 flex-1 space-y-0">
+                {[
+                  { t: "Parse & semantic analysis", d: "AST + type checking with explicit interface signatures", c: "text-white", dot: "bg-white/60" },
+                  { t: "Escape analysis pass", d: "side-table maps every binding → Stack / ARC Heap / Arena", c: "text-acid", dot: "bg-acid" },
+                  { t: "MIR + ARC insertion", d: "retain / release calls placed automatically", c: "text-lav", dot: "bg-lav" },
+                  { t: "Cranelift codegen", d: "native x86-64 object file, or optimized C via transpiler", c: "text-aqua", dot: "bg-aqua" },
+                  { t: "Link with lpp_runtime", d: "MSVC link.exe + lean C runtime → main.exe", c: "text-ember", dot: "bg-ember" },
+                ].map((s, i, arr) => (
+                  <motion.div
+                    key={s.t}
+                    initial={{ opacity: 0, x: -18 }}
+                    whileInView={{ opacity: 1, x: 0 }}
+                    viewport={{ once: true, margin: "-40px" }}
+                    transition={{ duration: 0.6, delay: i * 0.1, ease: EASE }}
+                    className="relative flex gap-4 pb-6 last:pb-0"
+                  >
+                    {i < arr.length - 1 && (
+                      <span className="absolute left-[5px] top-5 h-full w-px bg-white/[0.09]" />
+                    )}
+                    <span className={`mt-1.5 h-[11px] w-[11px] shrink-0 rounded-full border-2 border-ink ${s.dot}`} />
+                    <div>
+                      <p className={`font-mono text-[13px] font-semibold ${s.c}`}>{s.t}</p>
+                      <p className="mt-1 text-[13px] leading-snug text-white/40">{s.d}</p>
+                    </div>
+                  </motion.div>
+                ))}
+              </div>
+            </div>
+          </Reveal>
+        </div>
+
+        {/* stat cards */}
+        <div className="mt-6 grid gap-5 sm:grid-cols-2 lg:grid-cols-4">
+          {STATS.map((s, i) => (
+            <Reveal key={s.label} delay={i * 0.08}>
+              <div className="group rounded-2xl border border-white/[0.08] bg-panel p-6 transition-colors duration-300 hover:border-acid/30">
+                <s.icon className="h-[18px] w-[18px] text-acid/70" />
+                <p className="mt-4 font-display text-4xl font-bold tracking-tight text-white">
+                  {s.value}
+                </p>
+                <p className="mt-1.5 font-mono text-[11px] uppercase tracking-[0.14em] text-white/60">
+                  {s.label}
+                </p>
+                <p className="mt-2 text-[12.5px] leading-snug text-white/35">{s.sub}</p>
+              </div>
+            </Reveal>
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/website/src/components/Pillars.tsx
+++ b/website/src/components/Pillars.tsx
@@ -1,0 +1,83 @@
+import { Feather, Zap, ShieldCheck } from "lucide-react";
+import { SectionHead, Reveal } from "../lib/ui";
+import { Code } from "../lib/highlight";
+
+const PILLARS = [
+  {
+    icon: Feather,
+    color: "text-acid",
+    ring: "group-hover:border-acid/40",
+    chip: "border-acid/25 bg-acid/10 text-acid",
+    title: "Readable as Python",
+    body: "Significant whitespace, colon blocks, and := declarations. Types are explicit at function boundaries and inferred everywhere else. Code that reads like prose.",
+    code: `def greet(name: String) -> Void:\n    msg := "Hello, " + name\n    print(msg)`,
+    tag: "syntax.lpp",
+  },
+  {
+    icon: Zap,
+    color: "text-ember",
+    ring: "group-hover:border-ember/40",
+    chip: "border-ember/25 bg-ember/10 text-ember",
+    title: "Fast as C",
+    body: "The Cranelift AOT backend emits native x86-64 machine code — no VM, no interpreter, no JIT warmup. Recursive fib(35) runs in ~64 ms, toe-to-toe with gcc -O2.",
+    code: `# source -> native .exe in ~3 ms\n$ lpp main.lpp\n$ .\\main.exe   # 138 KB, zero deps`,
+    tag: "shell",
+  },
+  {
+    icon: ShieldCheck,
+    color: "text-lav",
+    ring: "group-hover:border-lav/40",
+    chip: "border-lav/25 bg-lav/10 text-lav",
+    title: "Safe as Rust",
+    body: "Immutable by default. Memory is managed by the compiler's escape analyzer — stack, ARC heap, or arena — with no data races by design, and no borrow checker to fight.",
+    code: `x := 5\n# x = 6   <- compile error\nmut y := 10\ny = 20      # explicit intent`,
+    tag: "safety.lpp",
+  },
+];
+
+export default function Pillars() {
+  return (
+    <section id="language" className="relative mx-auto max-w-7xl px-5 py-28 md:px-8 md:py-36">
+      <SectionHead
+        index="01"
+        kicker="One language, three promises"
+        title={
+          <>
+            The triangle, <span className="text-acid">finally closed.</span>
+          </>
+        }
+        desc="Languages have always forced a trade: pick two of readability, speed, and safety. L++ closes the triangle by moving memory management into the compiler's semantic analysis — where it belongs."
+      />
+
+      <div className="mt-14 grid gap-5 md:grid-cols-3">
+        {PILLARS.map((p, i) => (
+          <Reveal key={p.title} delay={i * 0.12}>
+            <div
+              className={`group relative flex h-full flex-col overflow-hidden rounded-2xl border border-white/[0.08] bg-panel p-7 transition-all duration-500 hover:-translate-y-1.5 ${p.ring}`}
+            >
+              <div className="pointer-events-none absolute -right-16 -top-16 h-40 w-40 rounded-full bg-white/[0.03] blur-2xl transition-opacity duration-500 group-hover:opacity-100" />
+              <p.icon className={`h-6 w-6 ${p.color}`} />
+              <h3 className="mt-5 font-display text-2xl font-semibold tracking-tight text-white">
+                {p.title}
+              </h3>
+              <p className="mt-3 flex-1 text-[15px] leading-relaxed text-white/50">{p.body}</p>
+              <div className="mt-6 overflow-hidden rounded-xl border border-white/[0.07] bg-ink/80">
+                <div className="flex items-center justify-between border-b border-white/[0.06] px-3.5 py-2">
+                  <span className="font-mono text-[10px] text-white/35">{p.tag}</span>
+                  <span className={`rounded border px-1.5 py-0.5 font-mono text-[9px] font-semibold uppercase tracking-wider ${p.chip}`}>
+                    l++
+                  </span>
+                </div>
+                <pre className="code-scroll overflow-x-auto p-4 font-mono text-[12px] leading-[1.7]">
+                  <code className="whitespace-pre">
+                    <Code src={p.code} />
+                  </code>
+                </pre>
+              </div>
+            </div>
+          </Reveal>
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/website/src/components/Roadmap.tsx
+++ b/website/src/components/Roadmap.tsx
@@ -1,0 +1,105 @@
+import { Check, Loader, Circle, FlaskConical } from "lucide-react";
+import { SectionHead, Reveal } from "../lib/ui";
+
+const LANES = [
+  {
+    title: "Verified now",
+    icon: Check,
+    color: "text-acid",
+    chip: "border-acid/30 bg-acid/10 text-acid",
+    items: [
+      { name: "King20 direct ELF", note: "20 / 20 Stable workloads without a host final linker" },
+      { name: "Ownership-aware MIR", note: "borrow, move, retain, release, ReturnOwned" },
+      { name: "ARC runtime", note: "structs, closures, List[Int], List[Custom], destructors" },
+      { name: "Linux native toolchain", note: "Cranelift ELF + lpp-link + syscall runtime" },
+    ],
+  },
+  {
+    title: "In motion",
+    icon: Loader,
+    color: "text-lav",
+    chip: "border-lav/30 bg-lav/10 text-lav",
+    items: [
+      { name: "Windows W1", note: "COFF inspection and MSVC fallback in CI" },
+      { name: "Windows PE linker", note: "section merge and AMD64 relocations next" },
+      { name: "Scalability", note: "escape analysis and AOT lowering are current 100k LOC targets" },
+    ],
+  },
+  {
+    title: "Next boundaries",
+    icon: Circle,
+    color: "text-white/50",
+    chip: "border-white/15 bg-white/[0.04] text-white/45",
+    items: [
+      { name: "Writable direct ELF data", note: ".data, .bss, writable relocations" },
+      { name: "Runtime expansion", note: "files, networking, threads, JSON" },
+      { name: "Windows 20 / 20", note: "King20 through direct PE output" },
+      { name: "Upstream Linguist", note: "awaiting maintainer review" },
+    ],
+  },
+];
+
+export default function Roadmap() {
+  return (
+    <section id="roadmap" className="relative border-t border-white/[0.06] py-28 md:py-36">
+      <div className="pointer-events-none absolute right-0 top-0 h-[360px] w-[360px] rounded-full bg-lav/[0.05] blur-[120px]" />
+      <div className="relative mx-auto max-w-7xl px-5 md:px-8">
+        <SectionHead
+          index="06"
+          kicker="Honest about the prototype"
+          title={
+            <>
+              Working today. <span className="text-acid">Ambitious tomorrow.</span>
+            </>
+          }
+          desc="L++ is an active prototype: the compiled core is real and fast, and the surface area grows every week. Here's exactly where things stand."
+        />
+
+        <div className="mt-14 grid gap-5 lg:grid-cols-3">
+          {LANES.map((lane, li) => (
+            <Reveal key={lane.title} delay={li * 0.1}>
+              <div className="h-full rounded-2xl border border-white/[0.08] bg-panel p-6">
+                <div className="mb-6 flex items-center gap-2.5">
+                  <lane.icon className={`h-4 w-4 ${lane.color}`} />
+                  <span className="font-display text-lg font-semibold tracking-tight text-white">
+                    {lane.title}
+                  </span>
+                  <span className={`ml-auto rounded border px-1.5 py-0.5 font-mono text-[9px] font-semibold uppercase tracking-wider ${lane.chip}`}>
+                    {lane.items.length}
+                  </span>
+                </div>
+                <div className="space-y-3">
+                  {lane.items.map((it) => (
+                    <div
+                      key={it.name}
+                      className="rounded-xl border border-white/[0.06] bg-ink/50 px-4 py-3 transition-colors hover:border-white/15"
+                    >
+                      <p className="font-mono text-[12.5px] font-medium text-white/80">{it.name}</p>
+                      <p className="mt-1 text-[12px] text-white/35">{it.note}</p>
+                    </div>
+                  ))}
+                </div>
+              </div>
+            </Reveal>
+          ))}
+        </div>
+
+        <Reveal delay={0.2} className="mt-6">
+          <div className="flex items-start gap-4 rounded-2xl border border-dashed border-aqua/25 bg-aqua/[0.03] p-6">
+            <FlaskConical className="mt-0.5 h-5 w-5 shrink-0 text-aqua" />
+            <div>
+              <p className="font-mono text-[13px] font-semibold text-aqua">
+                Research track — Escape Rule 6: Required Aliasing
+              </p>
+              <p className="mt-1.5 max-w-3xl text-[14px] leading-relaxed text-white/45">
+                The sixth promotion rule depends on language features still being designed. When it
+                lands, the hybrid model will cover the last known escape pattern — keeping the
+                "no GC, no borrow checker" promise complete.
+              </p>
+            </div>
+          </div>
+        </Reveal>
+      </div>
+    </section>
+  );
+}

--- a/website/src/components/Showcase.tsx
+++ b/website/src/components/Showcase.tsx
@@ -1,0 +1,188 @@
+import { useState } from "react";
+import { AnimatePresence, motion } from "framer-motion";
+import { Variable, Code2, Box, Sigma, Cpu, FileJson } from "lucide-react";
+import { SectionHead, Reveal, EASE } from "../lib/ui";
+import { CodeBlock } from "../lib/highlight";
+
+const TABS = [
+  {
+    id: "basics",
+    label: "Variables",
+    icon: Variable,
+    title: "variables.lpp",
+    code: `def greet() -> Void:
+    prefix := "Hello"
+    prefix := "Goodbye"  # shadows - never mutates
+
+    mut count := 0
+    count = count + 1    # ok: declared mut
+    # prefix = "Hi"      <- compile error: immutable
+
+    print(prefix)`,
+    note: "Immutable by default. := creates a brand-new binding that safely shadows; = mutates only what you explicitly marked mut.",
+  },
+  {
+    id: "functions",
+    label: "Functions",
+    icon: Code2,
+    title: "functions.lpp",
+    code: `def add(a: Int, b: Int) -> Int:
+    return a + b
+
+def main() -> Void:
+    total := add(20, 22)   # inferred: Int
+    print(total)           # 42`,
+    note: "Explicit types at the boundaries keep interfaces self-documenting and let the compiler type-check without analyzing the whole call graph. Locals are inferred.",
+  },
+  {
+    id: "structs",
+    label: "Structs",
+    icon: Box,
+    title: "structs.lpp",
+    code: `struct Node:
+    value: Int
+    next: Node   # self-reference -> Arena, automatic
+
+struct Box:
+    inner: Node
+    count: Int
+
+def safe_return() -> Int:
+    my_box := Box()
+    return my_box.count   # scalar copy - zero heap traffic`,
+    note: "No Box, no &, no allocation modifiers. Value semantics on the stack where possible; self-referential structs promote to Arenas on their own.",
+  },
+  {
+    id: "closures",
+    label: "Closures",
+    icon: Sigma,
+    title: "closures.lpp",
+    code: `def process() -> Void:
+    map(items, fn(x) -> x * 2)      # inline
+
+    multiplier := 5
+    callback := fn(x):              # block closure
+        mut y := x * multiplier     # captured + cloned
+        return y + 1
+
+    print(callback(21))             # 106`,
+    note: "fn closures infer parameter and return types. Immutable scalars are cloned by value; escaping captures promote to the Managed Heap automatically.",
+  },
+  {
+    id: "concurrency",
+    label: "Concurrency",
+    icon: Cpu,
+    title: "threads.lpp",
+    code: `def parallel_work() -> Void:
+    shared_readonly := 100
+    mut shared_state := 0
+
+    spawn fn() -> Void:
+        # readonly: copied by value
+        # shared_state: mut -> Managed Heap
+        print(shared_readonly, shared_state)`,
+    note: "spawn launches native threads. The compiler sees what crosses the boundary and picks copy vs. shared heap storage — thread safety without ceremony.",
+  },
+  {
+    id: "stdlib",
+    label: "JSON & Files",
+    icon: FileJson,
+    title: "config.lpp",
+    code: `def load_config() -> Void:
+    raw := read_file("config.json")
+    root := json_parse(raw)
+
+    name := json_get_str(root, "name")
+    retries := json_get_int(root, "retries")
+    print(name, retries)
+
+    json_free(root)   # recursive cleanup`,
+    note: "Built-ins map directly to optimal C stdlib calls: console, files, dynamic lists, and a full JSON parser — no package install required.",
+  },
+];
+
+export default function Showcase() {
+  const [active, setActive] = useState(0);
+  const tab = TABS[active];
+
+  return (
+    <section id="syntax" className="relative border-t border-white/[0.06] py-28 md:py-36">
+      <div className="pointer-events-none absolute right-0 top-24 h-[380px] w-[380px] rounded-full bg-acid/[0.05] blur-[120px]" />
+      <div className="relative mx-auto max-w-7xl px-5 md:px-8">
+        <SectionHead
+          index="03"
+          kicker="The language"
+          title={
+            <>
+              Python's handwriting, <span className="text-acid">a systems soul.</span>
+            </>
+          }
+          desc="Significant whitespace and colons define blocks — no curly braces, no semicolons. Every construct is designed to disappear so the logic can speak."
+        />
+
+        <Reveal delay={0.1} className="mt-12">
+          <div className="flex flex-wrap gap-2">
+            {TABS.map((t, i) => (
+              <button
+                key={t.id}
+                onClick={() => setActive(i)}
+                className={`flex items-center gap-2 rounded-lg border px-4 py-2.5 font-mono text-[12px] transition-all duration-300 ${
+                  i === active
+                    ? "border-acid/50 bg-acid/10 text-acid"
+                    : "border-white/[0.09] bg-panel text-white/50 hover:border-white/25 hover:text-white/80"
+                }`}
+              >
+                <t.icon className="h-3.5 w-3.5" />
+                {t.label}
+              </button>
+            ))}
+          </div>
+        </Reveal>
+
+        <div className="mt-6 grid gap-6 lg:grid-cols-[1.25fr_0.75fr]">
+          <Reveal delay={0.15}>
+            <AnimatePresence mode="wait">
+              <motion.div
+                key={tab.id}
+                initial={{ opacity: 0, y: 16 }}
+                animate={{ opacity: 1, y: 0 }}
+                exit={{ opacity: 0, y: -10 }}
+                transition={{ duration: 0.4, ease: EASE }}
+              >
+                <CodeBlock code={tab.code} title={tab.title} badge="l++" />
+              </motion.div>
+            </AnimatePresence>
+          </Reveal>
+          <Reveal delay={0.22}>
+            <div className="flex h-full flex-col justify-between gap-6 rounded-2xl border border-white/[0.08] bg-panel p-7">
+              <div>
+                <span className="font-mono text-[10px] uppercase tracking-[0.25em] text-white/35">
+                  why it works this way
+                </span>
+                <AnimatePresence mode="wait">
+                  <motion.p
+                    key={tab.id}
+                    initial={{ opacity: 0, y: 10 }}
+                    animate={{ opacity: 1, y: 0 }}
+                    exit={{ opacity: 0 }}
+                    transition={{ duration: 0.4, delay: 0.1 }}
+                    className="mt-4 text-[15.5px] leading-relaxed text-white/60"
+                  >
+                    {tab.note}
+                  </motion.p>
+                </AnimatePresence>
+              </div>
+              <div className="rounded-xl border border-white/[0.07] bg-ink/60 p-4 font-mono text-[11.5px] leading-relaxed text-white/40">
+                <span className="text-acid">design note —</span> the parser already supports{" "}
+                <span className="text-white/70">if / else</span>,{" "}
+                <span className="text-white/70">while</span>, relational operators and module
+                merging via <span className="text-white/70">import</span>. for-loops land with
+                iterator protocols next.
+              </div>
+            </div>
+          </Reveal>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/website/src/components/Stdlib.tsx
+++ b/website/src/components/Stdlib.tsx
@@ -1,0 +1,88 @@
+import { Terminal, Keyboard, FolderOpen, FileJson, Cpu, ListOrdered, Type, Globe } from "lucide-react";
+import { SectionHead, Reveal } from "../lib/ui";
+
+const CATS = [
+  { icon: Terminal, name: "Console", status: "full", fns: ["print(...)", "print_str(...)"] },
+  { icon: Keyboard, name: "Input", status: "full", fns: ["input()"] },
+  { icon: FolderOpen, name: "Files", status: "full", fns: ["read_file(p)", "write_file(p, d)"] },
+  { icon: FileJson, name: "JSON", status: "full", fns: ["json_parse", "json_get_int", "json_get_str", "json_get_obj", "json_free"] },
+  { icon: Cpu, name: "Threads", status: "native", fns: ["spawn fn() -> Void:"] },
+  { icon: ListOrdered, name: "Lists", status: "basic+", fns: ["[1, 2, 3]", "list_new", "list_push", "list_get", "list_len", "list_free"] },
+  { icon: Type, name: "Strings", status: "basic", fns: ["concat +", "interpolation soon"] },
+  { icon: Globe, name: "Networking", status: "soon", fns: ["sockets", "http"] },
+];
+
+const STATUS_STYLE: Record<string, string> = {
+  full: "border-acid/30 bg-acid/10 text-acid",
+  native: "border-lav/30 bg-lav/10 text-lav",
+  "basic+": "border-aqua/30 bg-aqua/10 text-aqua",
+  basic: "border-ember/30 bg-ember/10 text-ember",
+  soon: "border-white/15 bg-white/[0.04] text-white/40",
+};
+
+export default function Stdlib() {
+  return (
+    <section id="stdlib" className="relative border-t border-white/[0.06] py-28 md:py-36">
+      <div className="relative mx-auto max-w-7xl px-5 md:px-8">
+        <SectionHead
+          index="05"
+          kicker="Batteries, included and lean"
+          title={
+            <>
+              A stdlib that maps <span className="text-acid">straight to C.</span>
+            </>
+          }
+          desc="Built-ins aren't a runtime — they're thin bindings to optimal C stdlib calls. Full JSON parsing, dynamic lists, native threads and file I/O ship in the compiler today."
+        />
+
+        <div className="mt-14 grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
+          {CATS.map((c, i) => (
+            <Reveal key={c.name} delay={(i % 4) * 0.07}>
+              <div
+                className={`group h-full rounded-2xl border border-white/[0.08] bg-panel p-5 transition-all duration-300 hover:-translate-y-1 hover:border-white/20 ${
+                  c.status === "soon" ? "opacity-55" : ""
+                }`}
+              >
+                <div className="flex items-center justify-between">
+                  <c.icon className="h-[18px] w-[18px] text-white/60 transition-colors group-hover:text-acid" />
+                  <span
+                    className={`rounded border px-1.5 py-0.5 font-mono text-[9px] font-semibold uppercase tracking-wider ${STATUS_STYLE[c.status]}`}
+                  >
+                    {c.status}
+                  </span>
+                </div>
+                <h3 className="mt-4 font-display text-lg font-semibold tracking-tight text-white">
+                  {c.name}
+                </h3>
+                <div className="mt-3 flex flex-wrap gap-1.5">
+                  {c.fns.map((f) => (
+                    <code
+                      key={f}
+                      className="rounded-md border border-white/[0.07] bg-ink/70 px-2 py-1 font-mono text-[10.5px] text-white/55"
+                    >
+                      {f}
+                    </code>
+                  ))}
+                </div>
+              </div>
+            </Reveal>
+          ))}
+        </div>
+
+        <Reveal delay={0.15} className="mt-8">
+          <div className="flex flex-wrap items-center gap-x-8 gap-y-3 rounded-2xl border border-white/[0.08] bg-panel px-6 py-5">
+            <span className="font-mono text-[10px] uppercase tracking-[0.25em] text-white/35">
+              data types today
+            </span>
+            {["Int · 64-bit", "String", "Bool", "Void", "struct", "List[T]"].map((t) => (
+              <span key={t} className="font-mono text-[12px] text-white/60">
+                <span className="mr-2 text-acid">◆</span>
+                {t}
+              </span>
+            ))}
+          </div>
+        </Reveal>
+      </div>
+    </section>
+  );
+}

--- a/website/src/index.css
+++ b/website/src/index.css
@@ -1,0 +1,122 @@
+@import "tailwindcss";
+
+@theme {
+  --font-display: "Space Grotesk", ui-sans-serif, system-ui, sans-serif;
+  --font-sans: "Inter", ui-sans-serif, system-ui, sans-serif;
+  --font-mono: "JetBrains Mono", ui-monospace, SFMono-Regular, monospace;
+
+  --color-ink: #07080a;
+  --color-panel: #0c0e11;
+  --color-panel2: #101318;
+  --color-acid: #c8f14b;
+  --color-lav: #b7a3f5;
+  --color-aqua: #5fe3cf;
+  --color-ember: #f2c14e;
+
+  --animate-marquee: marquee 30s linear infinite;
+  --animate-blink: blink 1.05s step-end infinite;
+  --animate-scan: scan 2.4s ease-in-out infinite;
+  --animate-pulse-dot: pulseDot 2s ease-in-out infinite;
+
+  @keyframes marquee {
+    from { transform: translateX(0); }
+    to { transform: translateX(-50%); }
+  }
+  @keyframes blink {
+    0%, 49% { opacity: 1; }
+    50%, 100% { opacity: 0; }
+  }
+  @keyframes scan {
+    0% { top: 0%; opacity: 0; }
+    12% { opacity: 1; }
+    88% { opacity: 1; }
+    100% { top: 100%; opacity: 0; }
+  }
+  @keyframes pulseDot {
+    0%, 100% { opacity: 1; box-shadow: 0 0 0 0 rgb(200 241 75 / 0.5); }
+    50% { opacity: 0.6; box-shadow: 0 0 0 6px rgb(200 241 75 / 0); }
+  }
+}
+
+html {
+  scroll-behavior: smooth;
+  scroll-padding-top: 96px;
+}
+
+body {
+  background: var(--color-ink);
+  color: #e8eaee;
+  font-family: var(--font-sans);
+  -webkit-font-smoothing: antialiased;
+  overflow-x: hidden;
+}
+
+::selection {
+  background: var(--color-acid);
+  color: #07080a;
+}
+
+::-webkit-scrollbar {
+  width: 10px;
+  height: 8px;
+}
+::-webkit-scrollbar-track {
+  background: #0a0b0d;
+}
+::-webkit-scrollbar-thumb {
+  background: #23262c;
+  border-radius: 8px;
+  border: 2px solid #0a0b0d;
+}
+::-webkit-scrollbar-thumb:hover {
+  background: #33373f;
+}
+
+/* faint blueprint grid */
+.bg-grid {
+  background-image:
+    linear-gradient(to right, rgb(255 255 255 / 0.035) 1px, transparent 1px),
+    linear-gradient(to bottom, rgb(255 255 255 / 0.035) 1px, transparent 1px);
+  background-size: 56px 56px;
+}
+
+.bg-grid-fine {
+  background-image:
+    linear-gradient(to right, rgb(255 255 255 / 0.05) 1px, transparent 1px),
+    linear-gradient(to bottom, rgb(255 255 255 / 0.05) 1px, transparent 1px);
+  background-size: 28px 28px;
+}
+
+/* film grain */
+.noise::after {
+  content: "";
+  position: fixed;
+  inset: -50%;
+  z-index: 70;
+  pointer-events: none;
+  background-image: url("data:image/svg+xml,%3Csvg viewBox='0 0 300 300' xmlns='http://www.w3.org/2000/svg'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.72' numOctaves='3' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23n)'/%3E%3C/svg%3E");
+  opacity: 0.032;
+}
+
+.text-outline {
+  color: transparent;
+  -webkit-text-stroke: 1.5px rgb(232 234 238 / 0.85);
+}
+
+@media (min-width: 768px) {
+  .text-outline {
+    -webkit-text-stroke-width: 2px;
+  }
+}
+
+.glow-acid {
+  box-shadow: 0 0 24px rgb(200 241 75 / 0.35), 0 0 80px rgb(200 241 75 / 0.12);
+}
+
+.mask-fade-x {
+  mask-image: linear-gradient(to right, transparent, black 8%, black 92%, transparent);
+}
+
+.code-scroll::-webkit-scrollbar {
+  height: 6px;
+}

--- a/website/src/lib/highlight.tsx
+++ b/website/src/lib/highlight.tsx
@@ -1,0 +1,149 @@
+import { useMemo } from "react";
+
+/* ------------------------------------------------------------------ */
+/*  L++ tokenizer — hand-rolled, zero deps                             */
+/* ------------------------------------------------------------------ */
+
+const KEYWORDS = new Set([
+  "def", "return", "mut", "struct", "fn", "spawn", "if", "else",
+  "while", "import", "for", "in", "not", "and", "or", "break", "continue",
+]);
+const BOOLEANS = new Set(["true", "false", "True", "False"]);
+const BUILTINS = new Set([
+  "print", "print_str", "input", "read_file", "write_file",
+  "list_new", "list_push", "list_get", "list_len", "list_free",
+  "json_parse", "json_get_int", "json_get_str", "json_get_obj", "json_free",
+  "map", "range", "len",
+]);
+
+const C = {
+  kw: "text-acid",
+  type: "text-lav",
+  str: "text-ember",
+  com: "text-[#565d6b] italic",
+  num: "text-aqua",
+  bi: "text-[#7cc7ff]",
+  call: "text-[#eef0f4]",
+  op: "text-[#9aa0ac]",
+  id: "text-[#c9cdd6]",
+  pn: "text-[#6b7079]",
+};
+
+export interface Tok {
+  text: string;
+  cls: string;
+}
+
+const MASTER =
+  /(#.*$)|("(?:[^"\\]|\\.)*")|(\d[\d_]*)|(:=|->|==|!=|<=|>=|&&|\|\||[+\-*/%=<>])|([A-Za-z_][A-Za-z0-9_]*)|(\s+)|(.)/gm;
+
+export function tokenizeLine(src: string): Tok[] {
+  const toks: Tok[] = [];
+  MASTER.lastIndex = 0;
+  let m: RegExpExecArray | null;
+  while ((m = MASTER.exec(src)) !== null) {
+    const [full, com, str, num, op, ident, ws] = m;
+    if (com !== undefined) toks.push({ text: com, cls: C.com });
+    else if (str !== undefined) toks.push({ text: str, cls: C.str });
+    else if (num !== undefined) toks.push({ text: num, cls: C.num });
+    else if (op !== undefined) toks.push({ text: op, cls: C.op });
+    else if (ident !== undefined) {
+      if (KEYWORDS.has(ident)) toks.push({ text: ident, cls: C.kw });
+      else if (BOOLEANS.has(ident)) toks.push({ text: ident, cls: C.num });
+      else if (BUILTINS.has(ident)) toks.push({ text: ident, cls: C.bi });
+      else if (/^[A-Z]/.test(ident)) toks.push({ text: ident, cls: C.type });
+      else {
+        // peek ahead: function call?
+        const rest = src.slice(MASTER.lastIndex);
+        toks.push({ text: ident, cls: /^\s*\(/.test(rest) ? C.call : C.id });
+      }
+    } else if (ws !== undefined) toks.push({ text: ws, cls: "" });
+    else toks.push({ text: full, cls: C.pn });
+  }
+  return toks;
+}
+
+/* ------------------------------------------------------------------ */
+/*  <Code/> — renders tokenized source                                 */
+/* ------------------------------------------------------------------ */
+
+export function Code({ src }: { src: string }) {
+  const lines = useMemo(() => src.split("\n").map(tokenizeLine), [src]);
+  return (
+    <>
+      {lines.map((toks, i) => (
+        <span key={i} className="block">
+          {toks.map((t, j) => (
+            <span key={j} className={t.cls}>
+              {t.text}
+            </span>
+          ))}
+          {toks.length === 0 ? " " : ""}
+        </span>
+      ))}
+    </>
+  );
+}
+
+/* ------------------------------------------------------------------ */
+/*  <CodeBlock/> — window chrome + optional line highlighting          */
+/* ------------------------------------------------------------------ */
+
+interface CodeBlockProps {
+  code: string;
+  title?: string;
+  highlight?: number[]; // 1-indexed lines
+  lineNumbers?: boolean;
+  className?: string;
+  badge?: string;
+}
+
+export function CodeBlock({
+  code,
+  title = "main.lpp",
+  highlight,
+  lineNumbers = true,
+  className = "",
+  badge,
+}: CodeBlockProps) {
+  const lines = useMemo(() => code.split("\n"), [code]);
+  return (
+    <div
+      className={`overflow-hidden rounded-2xl border border-white/10 bg-panel shadow-[0_20px_60px_-20px_rgb(0_0_0/0.8)] ${className}`}
+    >
+      <div className="flex items-center gap-2 border-b border-white/[0.07] bg-white/[0.025] px-4 py-3">
+        <span className="h-2.5 w-2.5 rounded-full bg-[#ff5f57]" />
+        <span className="h-2.5 w-2.5 rounded-full bg-[#febc2e]" />
+        <span className="h-2.5 w-2.5 rounded-full bg-[#28c840]" />
+        <span className="ml-3 font-mono text-[11px] tracking-wide text-white/40">{title}</span>
+        {badge && (
+          <span className="ml-auto rounded-md border border-acid/25 bg-acid/10 px-2 py-0.5 font-mono text-[10px] font-medium text-acid">
+            {badge}
+          </span>
+        )}
+      </div>
+      <pre className="code-scroll overflow-x-auto p-5 font-mono text-[12.5px] leading-[1.75] md:text-[13px]">
+        {lines.map((ln, i) => {
+          const n = i + 1;
+          const hot = highlight?.includes(n);
+          const dim = highlight && !hot;
+          return (
+            <div
+              key={i}
+              className={`flex rounded-md transition-colors duration-300 ${
+                hot ? "bg-acid/[0.09] shadow-[inset_2px_0_0_0_var(--color-acid)]" : ""
+              } ${dim ? "opacity-45" : ""}`}
+            >
+              {lineNumbers && (
+                <span className="w-8 shrink-0 select-none pr-4 text-right text-white/20">{n}</span>
+              )}
+              <code className="whitespace-pre">
+                <Code src={ln} />
+              </code>
+            </div>
+          );
+        })}
+      </pre>
+    </div>
+  );
+}

--- a/website/src/lib/ui.tsx
+++ b/website/src/lib/ui.tsx
@@ -1,0 +1,56 @@
+import { motion } from "framer-motion";
+import type { ReactNode } from "react";
+
+export const EASE: [number, number, number, number] = [0.22, 1, 0.36, 1];
+
+export function Reveal({
+  children,
+  delay = 0,
+  className = "",
+  y = 28,
+}: {
+  children: ReactNode;
+  delay?: number;
+  className?: string;
+  y?: number;
+}) {
+  return (
+    <motion.div
+      initial={{ opacity: 0, y }}
+      whileInView={{ opacity: 1, y: 0 }}
+      viewport={{ once: true, margin: "-70px" }}
+      transition={{ duration: 0.8, delay, ease: EASE }}
+      className={className}
+    >
+      {children}
+    </motion.div>
+  );
+}
+
+export function SectionHead({
+  index,
+  kicker,
+  title,
+  desc,
+}: {
+  index: string;
+  kicker: string;
+  title: ReactNode;
+  desc?: ReactNode;
+}) {
+  return (
+    <Reveal className="max-w-3xl">
+      <div className="mb-5 flex items-center gap-3">
+        <span className="font-mono text-xs text-acid">[{index}]</span>
+        <span className="h-px w-10 bg-acid/40" />
+        <span className="font-mono text-[11px] uppercase tracking-[0.28em] text-white/45">
+          {kicker}
+        </span>
+      </div>
+      <h2 className="font-display text-4xl font-semibold leading-[1.04] tracking-tight text-white md:text-[3.4rem]">
+        {title}
+      </h2>
+      {desc && <p className="mt-5 text-lg leading-relaxed text-white/55">{desc}</p>}
+    </Reveal>
+  );
+}

--- a/website/src/main.tsx
+++ b/website/src/main.tsx
@@ -1,0 +1,10 @@
+import { StrictMode } from "react";
+import { createRoot } from "react-dom/client";
+import "./index.css";
+import App from "./App";
+
+createRoot(document.getElementById("root")!).render(
+  <StrictMode>
+    <App />
+  </StrictMode>
+);

--- a/website/src/utils/cn.ts
+++ b/website/src/utils/cn.ts
@@ -1,0 +1,6 @@
+import { clsx, type ClassValue } from "clsx";
+import { twMerge } from "tailwind-merge";
+
+export function cn(...inputs: ClassValue[]) {
+  return twMerge(clsx(inputs));
+}

--- a/website/tsconfig.json
+++ b/website/tsconfig.json
@@ -1,0 +1,31 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "useDefineForClassFields": true,
+    "lib": ["ES2020", "DOM", "DOM.Iterable"],
+    "module": "ESNext",
+    "skipLibCheck": true,
+    "types": ["node"],
+
+    /* Bundler mode */
+    "moduleResolution": "bundler",
+    "allowImportingTsExtensions": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "jsx": "react-jsx",
+
+    /* Path mapping */
+    "baseUrl": ".",
+    "paths": {
+      "@/*": ["src/*"]
+    },
+
+    /* Linting */
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noFallthroughCasesInSwitch": true
+  },
+  "include": ["src", "vite.config.ts"]
+}

--- a/website/vite.config.ts
+++ b/website/vite.config.ts
@@ -1,0 +1,21 @@
+import path from "path";
+import { fileURLToPath } from "url";
+import tailwindcss from "@tailwindcss/vite";
+import react from "@vitejs/plugin-react";
+import { defineConfig } from "vite";
+import { viteSingleFile } from "vite-plugin-singlefile";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+// https://vite.dev/config/
+export default defineConfig({
+  // GitHub Pages project site: https://samarnever-droid.github.io/lplusplus/
+  base: "/lplusplus/",
+  plugins: [react(), tailwindcss(), viteSingleFile()],
+  resolve: {
+    alias: {
+      "@": path.resolve(__dirname, "src"),
+    },
+  },
+});


### PR DESCRIPTION
## Summary

- imports the maintainable React/Vite source from the Page project into `website/`
- refreshes claims, benchmarks, direct linker status, Windows W1, commands, and branding
- uses the new four-pillar logo and 16x16 icon
- adds a GitHub Pages build/deploy workflow

## Verification

- `npm ci`
- `npm run build`
- verified output contains current King20, ownership, and Windows content