### PR TITLE
Add Kernel32 runtime imports to PE linker MVP

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -123,19 +123,27 @@ jobs:
           if ($inspect -notmatch "relocation-kinds:") { throw "Expected COFF relocation classification" }
           $actual = (Get-Content "$work\output.txt" | ForEach-Object { $_.Trim() }) -join "`n"
           if ($actual -ne "15`n5`n50`n2") { throw "Unexpected Windows AOT output: $actual" }
-      - name: Direct PE runtime-free MVP
+      - name: Direct PE Kernel32 runtime MVP
         shell: pwsh
         run: |
           $work = Join-Path $env:RUNNER_TEMP "lpp-windows-pe"
           New-Item -ItemType Directory -Force $work | Out-Null
           @"
           def main():
-              x := 1
+              print(7)
           "@ | Set-Content -Path "$work\direct.lpp" -Encoding ascii
-          $env:LPP_AOT = "1"
-          & .\target\release\lpp.exe "$work\direct.lpp"
-          if ($LASTEXITCODE -ne 0) { throw "PE MVP object generation failed" }
-          & .\target\release\lpp-link.exe pe "$work\direct.o" -o "$work\direct.exe"
-          if ($LASTEXITCODE -ne 0) { throw "PE MVP link failed" }
-          & "$work\direct.exe"
-          if ($LASTEXITCODE -ne 0) { throw "PE MVP executable returned $LASTEXITCODE" }
+          $cmd = Join-Path $work "direct.cmd"
+          @"
+          @echo off
+          call "%VSCMD_BAT%" >nul || exit /b 1
+          cl.exe /nologo /O2 /GS- /c runtime\windows_x86_64_min.c "/Fo:$work\lpp_runtime_min.obj" || exit /b 1
+          set LPP_AOT=1
+          target\release\lpp.exe "$work\direct.lpp" || exit /b 1
+          target\release\lpp-link.exe pe "$work\direct.o" "$work\lpp_runtime_min.obj" -o "$work\direct.exe" || exit /b 1
+          "$work\direct.exe" > "$work\output.txt" || exit /b 1
+          exit /b 0
+          "@ | Set-Content -Path $cmd -Encoding ascii
+          cmd.exe /d /c $cmd
+          if ($LASTEXITCODE -ne 0) { throw "PE Kernel32 runtime build failed" }
+          $actual = (Get-Content "$work\output.txt" | ForEach-Object { $_.Trim() }) -join "`n"
+          if ($actual -ne "7") { throw "Unexpected direct PE output: $actual" }

--- a/README.md
+++ b/README.md
@@ -197,8 +197,9 @@ Windows currently supports:
 ✓ Windows CI build and COFF fallback smoke test
 ✓ `lpp-link inspect` COFF / x86-64 inspection gate
 ✓ Runtime-free direct PE MVP in Windows CI
-⏳ COFF runtime section merge and broad AMD64 relocation coverage
-⏳ PE imports, ARC runtime, and King20 direct PE
+✓ Kernel32 import table / IAT MVP (`WriteFile`, `VirtualAlloc`)
+⏳ COFF `.rdata` / `.data` / `.bss` merge and broad AMD64 relocation coverage
+⏳ PE base relocations, full ARC/list/closure validation, and King20 direct PE
 ```
 
 The Windows direct-toolchain plan is in [`documentation/Windows_Native_Toolchain.md`](documentation/Windows_Native_Toolchain.md).

--- a/documentation/Windows_Native_Toolchain.md
+++ b/documentation/Windows_Native_Toolchain.md
@@ -46,24 +46,33 @@ DOS header
 PE signature
 COFF file header
 PE32+ optional header
-one executable .text section
+.text section
+.idata import section
 console subsystem metadata
 entry point at L++ main
 internal relative relocation application
+Kernel32 import table / IAT generation
 ```
 
-Windows CI generates a runtime-free L++ program, emits COFF, invokes `lpp-link pe`, runs the resulting `.exe`, and requires exit status zero.
+Windows CI compiles the freestanding Windows runtime object, emits a COFF program containing `print(7)`, invokes `lpp-link pe`, runs the resulting `.exe`, and requires exact output `7`.
 
-Still required before normal Windows direct builds:
+The direct runtime MVP resolves these Kernel32 APIs:
 
 ```text
-COFF runtime-object merge
-AMD64 relocation coverage
-PE import directory
-base relocations
-kernel32 imports
-WriteFile / VirtualAlloc runtime
-ARC / List / closure direct runtime
+GetStdHandle
+WriteFile
+VirtualAlloc
+VirtualFree
+```
+
+Still required before complete Windows direct builds:
+
+```text
+COFF .rdata / .data / .bss merge
+full AMD64 relocation coverage
+PE base relocations
+ARC/list/closure runtime validation across King20
+file, networking, JSON, and thread imports
 King20 20 / 20 direct PE gate
 ```
 

--- a/runtime/windows_x86_64_min.c
+++ b/runtime/windows_x86_64_min.c
@@ -1,0 +1,155 @@
+/*
+ * Freestanding Windows x86-64 direct-link runtime.
+ *
+ * This object is compiled by MSVC and merged by lpp-link PE. Its only external
+ * dependencies are Kernel32 imports emitted into the PE import directory.
+ */
+
+#include <stdint.h>
+#include <intrin.h>
+
+typedef void (*LppArcDestructor)(void *payload);
+typedef void *HANDLE;
+typedef unsigned long DWORD;
+typedef int BOOL;
+typedef unsigned long long SIZE_T;
+
+__declspec(dllimport) HANDLE __stdcall GetStdHandle(DWORD standard_handle);
+__declspec(dllimport) BOOL __stdcall WriteFile(HANDLE handle, const void *buffer, DWORD bytes_to_write, DWORD *bytes_written, void *overlapped);
+__declspec(dllimport) void *__stdcall VirtualAlloc(void *address, SIZE_T size, DWORD allocation_type, DWORD protect);
+__declspec(dllimport) BOOL __stdcall VirtualFree(void *address, SIZE_T size, DWORD free_type);
+
+#define STD_OUTPUT_HANDLE ((DWORD)-11)
+#define MEM_COMMIT  0x00001000UL
+#define MEM_RESERVE 0x00002000UL
+#define MEM_RELEASE 0x00008000UL
+#define PAGE_READWRITE 0x00000004UL
+
+typedef struct {
+    long refcount;
+    LppArcDestructor destructor;
+    uint64_t allocation_size;
+} LppArcHeader;
+
+typedef struct {
+    int64_t *data;
+    int64_t len;
+    int64_t cap;
+    uint64_t data_bytes;
+    int arc_elements;
+} LppList;
+
+static uint64_t lpp_page_round(uint64_t size) {
+    return (size + 4095ULL) & ~4095ULL;
+}
+
+static void lpp_write(const char *buffer, DWORD length) {
+    DWORD written = 0;
+    (void)WriteFile(GetStdHandle(STD_OUTPUT_HANDLE), buffer, length, &written, 0);
+}
+
+void lpp_print_int(int64_t value) {
+    char buffer[32];
+    char *cursor = buffer + sizeof(buffer);
+    uint64_t magnitude = value < 0 ? (uint64_t)(-(value + 1)) + 1 : (uint64_t)value;
+    *--cursor = '\n';
+    do {
+        *--cursor = (char)('0' + magnitude % 10);
+        magnitude /= 10;
+    } while (magnitude);
+    if (value < 0) *--cursor = '-';
+    lpp_write(cursor, (DWORD)((buffer + sizeof(buffer)) - cursor));
+}
+
+void lpp_print_str(const char *text) {
+    const char *end = text;
+    char newline = '\n';
+    if (!text) return;
+    while (*end) end++;
+    lpp_write(text, (DWORD)(end - text));
+    lpp_write(&newline, 1);
+}
+
+void *lpp_arc_alloc_with_destructor(int64_t payload_size, LppArcDestructor destructor) {
+    if (payload_size < 0) return 0;
+    uint64_t total = lpp_page_round((uint64_t)payload_size + sizeof(LppArcHeader));
+    LppArcHeader *header = (LppArcHeader *)VirtualAlloc(0, total, MEM_COMMIT | MEM_RESERVE, PAGE_READWRITE);
+    if (!header) return 0;
+    header->refcount = 1;
+    header->destructor = destructor;
+    header->allocation_size = total;
+    return header + 1;
+}
+
+void *lpp_arc_alloc(int64_t size) { return lpp_arc_alloc_with_destructor(size, 0); }
+
+void lpp_arc_retain(void *payload) {
+    if (!payload) return;
+    (void)_InterlockedIncrement(&((LppArcHeader *)payload - 1)->refcount);
+}
+
+void lpp_arc_release(void *payload) {
+    if (!payload) return;
+    LppArcHeader *header = (LppArcHeader *)payload - 1;
+    if (_InterlockedDecrement(&header->refcount) == 0) {
+        if (header->destructor) header->destructor(payload);
+        (void)VirtualFree(header, 0, MEM_RELEASE);
+    }
+}
+
+void *lpp_alloc(int64_t size) { return lpp_arc_alloc(size); }
+void lpp_free(void *payload, int64_t size) { (void)size; lpp_arc_release(payload); }
+
+void lpp_closure_destroy(void *closure) {
+    if (!closure) return;
+    lpp_arc_release(((void **)closure)[1]);
+}
+
+static void lpp_list_destroy(void *payload) {
+    LppList *list = (LppList *)payload;
+    if (!list) return;
+    if (list->arc_elements) {
+        for (int64_t i = 0; i < list->len; ++i) {
+            lpp_arc_release((void *)(intptr_t)list->data[i]);
+        }
+    }
+    if (list->data) (void)VirtualFree(list->data, 0, MEM_RELEASE);
+}
+
+static void *lpp_list_new_with_mode(int arc_elements) {
+    LppList *list = (LppList *)lpp_arc_alloc_with_destructor((int64_t)sizeof(LppList), lpp_list_destroy);
+    if (!list) return 0;
+    list->arc_elements = arc_elements;
+    return list;
+}
+
+void *lpp_list_new(void) { return lpp_list_new_with_mode(0); }
+void *lpp_list_new_arc(void) { return lpp_list_new_with_mode(1); }
+
+void lpp_list_push(void *raw, int64_t value) {
+    LppList *list = (LppList *)raw;
+    if (!list) return;
+    if (list->len == list->cap) {
+        int64_t next_cap = list->cap == 0 ? 8 : list->cap * 2;
+        if (next_cap < list->cap || next_cap > (int64_t)(0x7fffffffffffffffLL / 8)) return;
+        uint64_t next_bytes = lpp_page_round((uint64_t)next_cap * sizeof(int64_t));
+        int64_t *next_data = (int64_t *)VirtualAlloc(0, next_bytes, MEM_COMMIT | MEM_RESERVE, PAGE_READWRITE);
+        if (!next_data) return;
+        for (int64_t i = 0; i < list->len; ++i) next_data[i] = list->data[i];
+        if (list->data) (void)VirtualFree(list->data, 0, MEM_RELEASE);
+        list->data = next_data;
+        list->cap = next_cap;
+        list->data_bytes = next_bytes;
+    }
+    if (list->arc_elements) lpp_arc_retain((void *)(intptr_t)value);
+    list->data[list->len++] = value;
+}
+
+void lpp_list_push_arc(void *list, void *value) { lpp_list_push(list, (int64_t)(intptr_t)value); }
+int64_t lpp_list_get(void *raw, int64_t index) {
+    LppList *list = (LppList *)raw;
+    return (!list || index < 0 || index >= list->len) ? 0 : list->data[index];
+}
+void *lpp_list_get_arc(void *list, int64_t index) { return (void *)(intptr_t)lpp_list_get(list, index); }
+int64_t lpp_list_len(void *raw) { return raw ? ((LppList *)raw)->len : 0; }
+void lpp_list_free(void *list) { lpp_arc_release(list); }

--- a/src/bin/lpp-link.rs
+++ b/src/bin/lpp-link.rs
@@ -331,7 +331,9 @@ fn read_coff_input(path: &Path) -> Result<InputText, String> {
         if let SymbolSection::Section(index) = symbol.section() {
             if let Some(base) = section_base(index) {
                 if let Ok(name) = symbol.name() {
-                    if !name.is_empty() {
+                    // COFF emits local section symbols such as `.text$mn`.
+                    // They are relocation anchors, not linkable global names.
+                    if !name.is_empty() && !name.starts_with(".text") {
                         text_symbols.push((name.to_string(), base as u64 + symbol.address()));
                     }
                 }

--- a/src/bin/lpp-link.rs
+++ b/src/bin/lpp-link.rs
@@ -333,7 +333,7 @@ fn read_coff_input(path: &Path) -> Result<InputText, String> {
                 if let Ok(name) = symbol.name() {
                     // COFF emits local section symbols such as `.text$mn`.
                     // They are relocation anchors, not linkable global names.
-                    if !name.is_empty() && !name.starts_with(".text") {
+                    if !name.is_empty() && !name.starts_with(".text") && !name.starts_with('$') {
                         text_symbols.push((name.to_string(), base as u64 + symbol.address()));
                     }
                 }

--- a/src/bin/lpp-link.rs
+++ b/src/bin/lpp-link.rs
@@ -298,24 +298,49 @@ fn read_coff_input(path: &Path) -> Result<InputText, String> {
     if file.format() != BinaryFormat::Coff || file.architecture() != Architecture::X86_64 {
         return Err(format!("'{}' is not an x86-64 COFF object", path.display()));
     }
-    let text_section = file.section_by_name(".text")
-        .ok_or_else(|| format!("'{}' has no .text section", path.display()))?;
-    let text_index = text_section.index();
-    let text = text_section.uncompressed_data()
-        .map_err(|error| format!("read .text from '{}': {error}", path.display()))?
-        .into_owned();
+
+    // MSVC often emits one COMDAT text section per function (`.text$mn`,
+    // `.text$...`) rather than one literal `.text`. Merge every text-kind
+    // section into the linker input while retaining per-section offsets.
+    let mut text = Vec::new();
+    let mut section_bases = Vec::new();
+    let mut section_relocations = Vec::new();
+    for section in file.sections() {
+        if section.kind() != object::SectionKind::Text {
+            continue;
+        }
+        let base = align_up(text.len(), 16);
+        text.resize(base, 0x90);
+        let index = section.index();
+        let data = section.uncompressed_data()
+            .map_err(|error| format!("read text from '{}': {error}", path.display()))?
+            .into_owned();
+        text.extend_from_slice(&data);
+        section_bases.push((index, base));
+        for (offset, relocation) in section.relocations() {
+            section_relocations.push((index, base, offset, relocation));
+        }
+    }
+    if section_bases.is_empty() {
+        return Err(format!("'{}' has no executable COFF text section", path.display()));
+    }
+    let section_base = |index| section_bases.iter().find(|(candidate, _)| *candidate == index).map(|(_, base)| *base);
+
     let mut text_symbols = Vec::new();
     for symbol in file.symbols() {
-        if symbol.section() == SymbolSection::Section(text_index) {
-            if let Ok(name) = symbol.name() {
-                if !name.is_empty() {
-                    text_symbols.push((name.to_string(), symbol.address()));
+        if let SymbolSection::Section(index) = symbol.section() {
+            if let Some(base) = section_base(index) {
+                if let Ok(name) = symbol.name() {
+                    if !name.is_empty() {
+                        text_symbols.push((name.to_string(), base as u64 + symbol.address()));
+                    }
                 }
             }
         }
     }
+
     let mut relocations = Vec::new();
-    for (offset, relocation) in text_section.relocations() {
+    for (_, base, offset, relocation) in section_relocations {
         let RelocationTarget::Symbol(symbol_index) = relocation.target() else {
             return Err(format!("'{}' has unsupported non-symbol relocation", path.display()));
         };
@@ -323,13 +348,18 @@ fn read_coff_input(path: &Path) -> Result<InputText, String> {
             .map_err(|error| format!("read relocation symbol: {error}"))?;
         let raw_name = symbol.name()
             .map_err(|error| format!("read relocation symbol name: {error}"))?;
-        let target = if raw_name.is_empty() && symbol.section() == SymbolSection::Section(text_index) {
-            "__self_text__".to_string()
+        let target = if raw_name.is_empty() {
+            match symbol.section() {
+                SymbolSection::Section(index) if section_base(index).is_some() => {
+                    format!("__coff_text_section_{}", section_base(index).unwrap())
+                }
+                _ => return Err(format!("'{}' has unresolved anonymous COFF relocation", path.display())),
+            }
         } else {
             raw_name.to_string()
         };
         relocations.push(Relocation {
-            offset: usize::try_from(offset).map_err(|_| "relocation offset overflow")?,
+            offset: base + usize::try_from(offset).map_err(|_| "relocation offset overflow")?,
             target,
             addend: relocation.addend(),
             size: relocation.size(),
@@ -438,6 +468,8 @@ fn write_pe(inputs: &[PathBuf], output: &Path) -> Result<(), String> {
             }
             let target_rva: u32 = if relocation.target == "__self_text__" {
                 PE_SECTION_RVA + base as u32
+            } else if let Some(offset) = relocation.target.strip_prefix("__coff_text_section_") {
+                PE_SECTION_RVA + offset.parse::<u32>().map_err(|_| "invalid COFF section relocation")?
             } else if let Some(rva) = iat_rvas.get(&relocation.target) {
                 *rva
             } else {

--- a/src/bin/lpp-link.rs
+++ b/src/bin/lpp-link.rs
@@ -353,6 +353,47 @@ fn pe_align(value: usize, alignment: usize) -> usize {
 /// Phase W2 PE MVP: merge runtime-free COFF `.text` sections into a console
 /// x86-64 PE executable. Runtime imports, data sections, and base relocations
 /// intentionally remain unsupported until W2 section/relocation coverage grows.
+fn build_kernel32_imports(imports: &[String], section_rva: u32) -> Result<(Vec<u8>, HashMap<String, u32>), String> {
+    if imports.is_empty() {
+        return Ok((Vec::new(), HashMap::new()));
+    }
+    let count = imports.len();
+    let descriptor_size = 40usize; // descriptor + terminating zero descriptor
+    let ilt_offset = align_up(descriptor_size, 8);
+    let iat_offset = ilt_offset + (count + 1) * 8;
+    let dll_offset = iat_offset + (count + 1) * 8;
+    let mut data = vec![0_u8; dll_offset];
+    data.extend_from_slice(b"KERNEL32.dll\0");
+    while data.len() % 2 != 0 { data.push(0); }
+    let mut names = HashMap::new();
+    for import in imports {
+        let offset = data.len();
+        data.extend_from_slice(&[0, 0]); // hint
+        data.extend_from_slice(import.as_bytes());
+        data.push(0);
+        while data.len() % 2 != 0 { data.push(0); }
+        names.insert(import.clone(), offset);
+    }
+    let mut iat_rvas = HashMap::new();
+    for (index, import) in imports.iter().enumerate() {
+        let name_rva = section_rva + names[import] as u32;
+        let thunk = name_rva as u64;
+        let ilt = ilt_offset + index * 8;
+        let iat = iat_offset + index * 8;
+        data[ilt..ilt + 8].copy_from_slice(&thunk.to_le_bytes());
+        data[iat..iat + 8].copy_from_slice(&thunk.to_le_bytes());
+        iat_rvas.insert(format!("__imp_{import}"), section_rva + iat as u32);
+    }
+    // IMAGE_IMPORT_DESCRIPTOR for KERNEL32.dll.
+    put_u32(&mut data, 0, section_rva + ilt_offset as u32); // OriginalFirstThunk
+    put_u32(&mut data, 12, section_rva + dll_offset as u32); // Name
+    put_u32(&mut data, 16, section_rva + iat_offset as u32); // FirstThunk
+    Ok((data, iat_rvas))
+}
+
+/// Phase W2: merge x86-64 COFF text and emit a console PE32+ image. The
+/// runtime imports are limited to KERNEL32.dll and use a generated import/IAT
+/// section. This is intentionally still a narrow static-layout linker.
 fn write_pe(inputs: &[PathBuf], output: &Path) -> Result<(), String> {
     if inputs.is_empty() {
         return Err("at least one input object is required".to_string());
@@ -361,6 +402,7 @@ fn write_pe(inputs: &[PathBuf], output: &Path) -> Result<(), String> {
     let mut text = Vec::new();
     let mut bases = Vec::new();
     let mut symbols: HashMap<String, u64> = HashMap::new();
+    let mut imports = Vec::new();
     for input in &objects {
         let base = align_up(text.len(), 16);
         text.resize(base, 0x90);
@@ -371,10 +413,22 @@ fn write_pe(inputs: &[PathBuf], output: &Path) -> Result<(), String> {
                 return Err(format!("duplicate definition of symbol '{name}'"));
             }
         }
+        for relocation in &input.relocations {
+            if relocation.target.starts_with("__imp_") {
+                let name = relocation.target.trim_start_matches("__imp_").to_string();
+                if !imports.contains(&name) { imports.push(name); }
+            }
+        }
         text.extend_from_slice(&input.text);
     }
     let main = *symbols.get("main").ok_or_else(|| "required symbol 'main' not found".to_string())?;
     let _lpp_main = symbols.get("lpp_main").ok_or_else(|| "required symbol 'lpp_main' not found".to_string())?;
+
+    let headers_size = PE_FILE_ALIGNMENT;
+    let text_raw_size = pe_align(text.len(), PE_FILE_ALIGNMENT);
+    let idata_rva = pe_align(PE_SECTION_RVA as usize + text.len(), PE_SECTION_ALIGNMENT) as u32;
+    let (idata, iat_rvas) = build_kernel32_imports(&imports, idata_rva)?;
+    let has_imports = !idata.is_empty();
 
     for (index, input) in objects.iter().enumerate() {
         let base = bases[index];
@@ -382,28 +436,28 @@ fn write_pe(inputs: &[PathBuf], output: &Path) -> Result<(), String> {
             if relocation.size != 32 {
                 return Err(format!("'{}': unsupported COFF relocation width {}", input.path.display(), relocation.size));
             }
-            if relocation.kind == RelocationKind::GotRelative {
-                return Err(format!("'{}': PE MVP does not yet support runtime GOT import '{}'", input.path.display(), relocation.target));
-            }
-            let target = if relocation.target == "__self_text__" {
-                base as u64
+            let target_rva: u32 = if relocation.target == "__self_text__" {
+                PE_SECTION_RVA + base as u32
+            } else if let Some(rva) = iat_rvas.get(&relocation.target) {
+                *rva
             } else {
-                *symbols.get(&relocation.target).ok_or_else(|| {
+                PE_SECTION_RVA + *symbols.get(&relocation.target).ok_or_else(|| {
                     format!("'{}': unresolved external COFF symbol '{}'", input.path.display(), relocation.target)
-                })?
+                })? as u32
             };
             let patch = base + relocation.offset;
             if patch + 4 > text.len() {
                 return Err(format!("'{}': relocation patch out of range", input.path.display()));
             }
+            let patch_rva = PE_SECTION_RVA as i64 + patch as i64;
             if relocation.kind == RelocationKind::Absolute {
-                let value = PE_IMAGE_BASE as i64 + PE_SECTION_RVA as i64 + target as i64 + relocation.addend;
+                let value = PE_IMAGE_BASE as i64 + target_rva as i64 + relocation.addend;
                 if value < i32::MIN as i64 || value > i32::MAX as i64 {
-                    return Err("COFF absolute relocation out of range; base relocations are not implemented".to_string());
+                    return Err("COFF absolute relocation out of range; PE base relocations are not implemented".to_string());
                 }
                 text[patch..patch + 4].copy_from_slice(&(value as i32).to_le_bytes());
             } else {
-                let displacement = target as i64 + relocation.addend - patch as i64;
+                let displacement = target_rva as i64 + relocation.addend - patch_rva;
                 if displacement < i32::MIN as i64 || displacement > i32::MAX as i64 {
                     return Err("COFF PC-relative relocation out of range".to_string());
                 }
@@ -412,45 +466,71 @@ fn write_pe(inputs: &[PathBuf], output: &Path) -> Result<(), String> {
         }
     }
 
-    let headers_size = PE_FILE_ALIGNMENT;
-    let raw_size = pe_align(text.len(), PE_FILE_ALIGNMENT);
-    let image_size = pe_align(PE_SECTION_RVA as usize + text.len(), PE_SECTION_ALIGNMENT);
-    let mut pe = vec![0_u8; headers_size + raw_size];
+    let idata_raw_size = if has_imports { pe_align(idata.len(), PE_FILE_ALIGNMENT) } else { 0 };
+    let idata_raw_offset = headers_size + text_raw_size;
+    let section_count = if has_imports { 2 } else { 1 };
+    let image_end = if has_imports {
+        idata_rva as usize + idata.len()
+    } else {
+        PE_SECTION_RVA as usize + text.len()
+    };
+    let image_size = pe_align(image_end, PE_SECTION_ALIGNMENT);
+    let mut pe = vec![0_u8; headers_size + text_raw_size + idata_raw_size];
     pe[0..2].copy_from_slice(b"MZ");
     put_u32(&mut pe, 0x3c, 0x80);
     let nt = 0x80;
     pe[nt..nt + 4].copy_from_slice(b"PE\0\0");
-    // COFF file header
-    put_u16(&mut pe, nt + 4, 0x8664); // AMD64
-    put_u16(&mut pe, nt + 6, 1);      // one section
-    put_u16(&mut pe, nt + 20, 0xF0);  // optional header size
-    put_u16(&mut pe, nt + 22, 0x0022); // executable + large address aware
+    put_u16(&mut pe, nt + 4, 0x8664);
+    put_u16(&mut pe, nt + 6, section_count);
+    put_u16(&mut pe, nt + 20, 0xF0);
+    put_u16(&mut pe, nt + 22, 0x0022);
     let opt = nt + 24;
-    put_u16(&mut pe, opt, 0x20b);     // PE32+
-    put_u32(&mut pe, opt + 4, raw_size as u32);
-    put_u32(&mut pe, opt + 16, PE_SECTION_RVA + main as u32); // entry RVA
+    put_u16(&mut pe, opt, 0x20b);
+    put_u32(&mut pe, opt + 4, text_raw_size as u32);
+    put_u32(&mut pe, opt + 8, idata_raw_size as u32);
+    put_u32(&mut pe, opt + 16, PE_SECTION_RVA + main as u32);
     put_u32(&mut pe, opt + 20, PE_SECTION_RVA);
     put_u64(&mut pe, opt + 24, PE_IMAGE_BASE);
     put_u32(&mut pe, opt + 32, PE_SECTION_ALIGNMENT as u32);
     put_u32(&mut pe, opt + 36, PE_FILE_ALIGNMENT as u32);
-    put_u16(&mut pe, opt + 40, 6);    // OS major
-    put_u16(&mut pe, opt + 48, 6);    // subsystem major
+    put_u16(&mut pe, opt + 40, 6);
+    put_u16(&mut pe, opt + 48, 6);
     put_u32(&mut pe, opt + 56, image_size as u32);
     put_u32(&mut pe, opt + 60, headers_size as u32);
-    put_u16(&mut pe, opt + 68, 3);    // Windows CUI
-    put_u64(&mut pe, opt + 72, 0x100000); // stack reserve
-    put_u64(&mut pe, opt + 80, 0x1000);   // stack commit
-    put_u64(&mut pe, opt + 88, 0x100000); // heap reserve
-    put_u64(&mut pe, opt + 96, 0x1000);   // heap commit
-    put_u32(&mut pe, opt + 108, 16);      // data directory count
+    put_u16(&mut pe, opt + 68, 3); // console
+    put_u64(&mut pe, opt + 72, 0x100000);
+    put_u64(&mut pe, opt + 80, 0x1000);
+    put_u64(&mut pe, opt + 88, 0x100000);
+    put_u64(&mut pe, opt + 96, 0x1000);
+    put_u32(&mut pe, opt + 108, 16);
+    if has_imports {
+        let directories = opt + 112;
+        put_u32(&mut pe, directories + 8, idata_rva); // import table directory #1
+        put_u32(&mut pe, directories + 12, 40);       // descriptor + terminator
+        let first_iat_rva = iat_rvas.values().copied().min().unwrap_or(idata_rva);
+        put_u32(&mut pe, directories + 12 * 8, first_iat_rva); // IAT directory #12
+        put_u32(&mut pe, directories + 12 * 8 + 4, (imports.len() as u32 + 1) * 8);
+    }
     let section = opt + 0xF0;
     pe[section..section + 5].copy_from_slice(b".text");
     put_u32(&mut pe, section + 8, text.len() as u32);
     put_u32(&mut pe, section + 12, PE_SECTION_RVA);
-    put_u32(&mut pe, section + 16, raw_size as u32);
+    put_u32(&mut pe, section + 16, text_raw_size as u32);
     put_u32(&mut pe, section + 20, headers_size as u32);
-    put_u32(&mut pe, section + 36, 0x60000020); // code | execute | read
+    put_u32(&mut pe, section + 36, 0x60000020);
+    if has_imports {
+        let idata_section = section + 40;
+        pe[idata_section..idata_section + 6].copy_from_slice(b".idata");
+        put_u32(&mut pe, idata_section + 8, idata.len() as u32);
+        put_u32(&mut pe, idata_section + 12, idata_rva);
+        put_u32(&mut pe, idata_section + 16, idata_raw_size as u32);
+        put_u32(&mut pe, idata_section + 20, idata_raw_offset as u32);
+        put_u32(&mut pe, idata_section + 36, 0xC0000040);
+    }
     pe[headers_size..headers_size + text.len()].copy_from_slice(&text);
+    if has_imports {
+        pe[idata_raw_offset..idata_raw_offset + idata.len()].copy_from_slice(&idata);
+    }
     fs::write(output, pe).map_err(|error| format!("write '{}': {error}", output.display()))?;
     Ok(())
 }

--- a/src/bin/lpp-link.rs
+++ b/src/bin/lpp-link.rs
@@ -385,42 +385,52 @@ fn pe_align(value: usize, alignment: usize) -> usize {
 /// Phase W2 PE MVP: merge runtime-free COFF `.text` sections into a console
 /// x86-64 PE executable. Runtime imports, data sections, and base relocations
 /// intentionally remain unsupported until W2 section/relocation coverage grows.
-fn build_kernel32_imports(imports: &[String], section_rva: u32) -> Result<(Vec<u8>, HashMap<String, u32>), String> {
-    if imports.is_empty() {
-        return Ok((Vec::new(), HashMap::new()));
-    }
+fn build_kernel32_imports(
+    imports: &[String],
+    internal_refs: &[String],
+    section_rva: u32,
+) -> Result<(Vec<u8>, HashMap<String, u32>, HashMap<String, usize>), String> {
+    // descriptor + terminating descriptor; keep an .idata-like table even when
+    // only internal refptrs are present so code has a stable writable address.
     let count = imports.len();
-    let descriptor_size = 40usize; // descriptor + terminating zero descriptor
+    let descriptor_size = if count == 0 { 0 } else { 40usize };
     let ilt_offset = align_up(descriptor_size, 8);
     let iat_offset = ilt_offset + (count + 1) * 8;
-    let dll_offset = iat_offset + (count + 1) * 8;
-    let mut data = vec![0_u8; dll_offset];
-    data.extend_from_slice(b"KERNEL32.dll\0");
-    while data.len() % 2 != 0 { data.push(0); }
-    let mut names = HashMap::new();
-    for import in imports {
-        let offset = data.len();
-        data.extend_from_slice(&[0, 0]); // hint
-        data.extend_from_slice(import.as_bytes());
-        data.push(0);
-        while data.len() % 2 != 0 { data.push(0); }
-        names.insert(import.clone(), offset);
-    }
+    let refptr_offset = align_up(iat_offset + if count == 0 { 0 } else { (count + 1) * 8 }, 8);
+    let mut data = vec![0_u8; refptr_offset + internal_refs.len() * 8];
     let mut iat_rvas = HashMap::new();
-    for (index, import) in imports.iter().enumerate() {
-        let name_rva = section_rva + names[import] as u32;
-        let thunk = name_rva as u64;
-        let ilt = ilt_offset + index * 8;
-        let iat = iat_offset + index * 8;
-        data[ilt..ilt + 8].copy_from_slice(&thunk.to_le_bytes());
-        data[iat..iat + 8].copy_from_slice(&thunk.to_le_bytes());
-        iat_rvas.insert(format!("__imp_{import}"), section_rva + iat as u32);
+    let mut refptr_offsets = HashMap::new();
+
+    if count != 0 {
+        let dll_offset = data.len();
+        data.extend_from_slice(b"KERNEL32.dll\0");
+        while data.len() % 2 != 0 { data.push(0); }
+        let mut names = HashMap::new();
+        for import in imports {
+            let offset = data.len();
+            data.extend_from_slice(&[0, 0]); // hint
+            data.extend_from_slice(import.as_bytes());
+            data.push(0);
+            while data.len() % 2 != 0 { data.push(0); }
+            names.insert(import.clone(), offset);
+        }
+        for (index, import) in imports.iter().enumerate() {
+            let name_rva = section_rva + names[import] as u32;
+            let thunk = name_rva as u64;
+            let ilt = ilt_offset + index * 8;
+            let iat = iat_offset + index * 8;
+            data[ilt..ilt + 8].copy_from_slice(&thunk.to_le_bytes());
+            data[iat..iat + 8].copy_from_slice(&thunk.to_le_bytes());
+            iat_rvas.insert(format!("__imp_{import}"), section_rva + iat as u32);
+        }
+        put_u32(&mut data, 0, section_rva + ilt_offset as u32);
+        put_u32(&mut data, 12, section_rva + dll_offset as u32);
+        put_u32(&mut data, 16, section_rva + iat_offset as u32);
     }
-    // IMAGE_IMPORT_DESCRIPTOR for KERNEL32.dll.
-    put_u32(&mut data, 0, section_rva + ilt_offset as u32); // OriginalFirstThunk
-    put_u32(&mut data, 12, section_rva + dll_offset as u32); // Name
-    put_u32(&mut data, 16, section_rva + iat_offset as u32); // FirstThunk
-    Ok((data, iat_rvas))
+    for (index, name) in internal_refs.iter().enumerate() {
+        refptr_offsets.insert(format!(".refptr.{name}"), refptr_offset + index * 8);
+    }
+    Ok((data, iat_rvas, refptr_offsets))
 }
 
 /// Phase W2: merge x86-64 COFF text and emit a console PE32+ image. The
@@ -435,6 +445,7 @@ fn write_pe(inputs: &[PathBuf], output: &Path) -> Result<(), String> {
     let mut bases = Vec::new();
     let mut symbols: HashMap<String, u64> = HashMap::new();
     let mut imports = Vec::new();
+    let mut internal_refs = Vec::new();
     for input in &objects {
         let base = align_up(text.len(), 16);
         text.resize(base, 0x90);
@@ -449,6 +460,9 @@ fn write_pe(inputs: &[PathBuf], output: &Path) -> Result<(), String> {
             if relocation.target.starts_with("__imp_") {
                 let name = relocation.target.trim_start_matches("__imp_").to_string();
                 if !imports.contains(&name) { imports.push(name); }
+            } else if let Some(name) = relocation.target.strip_prefix(".refptr.") {
+                let name = name.to_string();
+                if !internal_refs.contains(&name) { internal_refs.push(name); }
             }
         }
         text.extend_from_slice(&input.text);
@@ -459,8 +473,19 @@ fn write_pe(inputs: &[PathBuf], output: &Path) -> Result<(), String> {
     let headers_size = PE_FILE_ALIGNMENT;
     let text_raw_size = pe_align(text.len(), PE_FILE_ALIGNMENT);
     let idata_rva = pe_align(PE_SECTION_RVA as usize + text.len(), PE_SECTION_ALIGNMENT) as u32;
-    let (idata, iat_rvas) = build_kernel32_imports(&imports, idata_rva)?;
-    let has_imports = !idata.is_empty();
+    let (mut idata, iat_rvas, refptr_offsets) = build_kernel32_imports(&imports, &internal_refs, idata_rva)?;
+    // Cranelift COFF emits .refptr.<symbol> variables for runtime function
+    // addresses. Populate those slots with fixed-base addresses in this MVP.
+    for (ref_name, offset) in &refptr_offsets {
+        let symbol_name = ref_name.trim_start_matches(".refptr.");
+        let target = *symbols.get(symbol_name).ok_or_else(|| {
+            format!("unresolved internal refptr symbol '{symbol_name}'")
+        })?;
+        let value = PE_IMAGE_BASE + PE_SECTION_RVA as u64 + target;
+        idata[*offset..*offset + 8].copy_from_slice(&value.to_le_bytes());
+    }
+    let has_kernel_imports = !imports.is_empty();
+    let has_idata = !idata.is_empty();
 
     for (index, input) in objects.iter().enumerate() {
         let base = bases[index];
@@ -474,6 +499,8 @@ fn write_pe(inputs: &[PathBuf], output: &Path) -> Result<(), String> {
                 PE_SECTION_RVA + offset.parse::<u32>().map_err(|_| "invalid COFF section relocation")?
             } else if let Some(rva) = iat_rvas.get(&relocation.target) {
                 *rva
+            } else if let Some(offset) = refptr_offsets.get(&relocation.target) {
+                idata_rva + *offset as u32
             } else {
                 PE_SECTION_RVA + *symbols.get(&relocation.target).ok_or_else(|| {
                     format!("'{}': unresolved external COFF symbol '{}'", input.path.display(), relocation.target)
@@ -500,10 +527,10 @@ fn write_pe(inputs: &[PathBuf], output: &Path) -> Result<(), String> {
         }
     }
 
-    let idata_raw_size = if has_imports { pe_align(idata.len(), PE_FILE_ALIGNMENT) } else { 0 };
+    let idata_raw_size = if has_idata { pe_align(idata.len(), PE_FILE_ALIGNMENT) } else { 0 };
     let idata_raw_offset = headers_size + text_raw_size;
-    let section_count = if has_imports { 2 } else { 1 };
-    let image_end = if has_imports {
+    let section_count = if has_idata { 2 } else { 1 };
+    let image_end = if has_idata {
         idata_rva as usize + idata.len()
     } else {
         PE_SECTION_RVA as usize + text.len()
@@ -537,7 +564,7 @@ fn write_pe(inputs: &[PathBuf], output: &Path) -> Result<(), String> {
     put_u64(&mut pe, opt + 88, 0x100000);
     put_u64(&mut pe, opt + 96, 0x1000);
     put_u32(&mut pe, opt + 108, 16);
-    if has_imports {
+    if has_kernel_imports {
         let directories = opt + 112;
         put_u32(&mut pe, directories + 8, idata_rva); // import table directory #1
         put_u32(&mut pe, directories + 12, 40);       // descriptor + terminator
@@ -552,7 +579,7 @@ fn write_pe(inputs: &[PathBuf], output: &Path) -> Result<(), String> {
     put_u32(&mut pe, section + 16, text_raw_size as u32);
     put_u32(&mut pe, section + 20, headers_size as u32);
     put_u32(&mut pe, section + 36, 0x60000020);
-    if has_imports {
+    if has_idata {
         let idata_section = section + 40;
         pe[idata_section..idata_section + 6].copy_from_slice(b".idata");
         put_u32(&mut pe, idata_section + 8, idata.len() as u32);
@@ -562,7 +589,7 @@ fn write_pe(inputs: &[PathBuf], output: &Path) -> Result<(), String> {
         put_u32(&mut pe, idata_section + 36, 0xC0000040);
     }
     pe[headers_size..headers_size + text.len()].copy_from_slice(&text);
-    if has_imports {
+    if has_idata {
         pe[idata_raw_offset..idata_raw_offset + idata.len()].copy_from_slice(&idata);
     }
     fs::write(output, pe).map_err(|error| format!("write '{}': {error}", output.display()))?;


### PR DESCRIPTION
## Summary

- adds a freestanding Windows x86-64 runtime object
- adds PE `.idata` import table and IAT generation for Kernel32 imports
- resolves `__imp_*` COFF import relocations
- adds Windows CI coverage for `print(7)` through direct COFF → PE linking
- lays groundwork for ARC, closure, and list runtime support on Windows

## Kernel32 imports

- GetStdHandle
- WriteFile
- VirtualAlloc
- VirtualFree

## Boundaries

This remains a narrow W2/W3 PE linker slice. It does not yet claim `.rdata/.data/.bss` merge, base relocations, full PE import coverage, or King20 direct PE completion.

## Verification

- `cargo test` on Linux
- Windows CI runs the actual MSVC COFF and PE executable path