### PR TITLE
Windows direct PE runtime and King20 gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,7 @@ on:
     branches: [master]
   pull_request:
     branches: [master]
+  workflow_dispatch:
 
 permissions:
   contents: read

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -147,3 +147,6 @@ jobs:
           if ($LASTEXITCODE -ne 0) { throw "PE Kernel32 runtime build failed" }
           $actual = (Get-Content "$work\output.txt" | ForEach-Object { $_.Trim() }) -join "`n"
           if ($actual -ne "7") { throw "Unexpected direct PE output: $actual" }
+      - name: King20 direct PE gate
+        shell: pwsh
+        run: .\tests\test_direct_pe_king20.ps1

--- a/documentation/Windows_Native_Toolchain.md
+++ b/documentation/Windows_Native_Toolchain.md
@@ -90,9 +90,11 @@ import table generation
 
 The direct PE linker must generate a valid import directory for the required Win32 APIs.
 
-## Phase W4 — King 20 Windows direct-link gate
+## Phase W4 — King 20 Windows direct-link gate — started
 
-The gate is:
+Windows CI now contains a direct PE King20 gate that compiles the freestanding Windows runtime, builds all 20 Stable inputs to COFF, links each with `lpp-link pe`, runs each `.exe`, and checks exact stdout.
+
+The completion gate remains:
 
 ```text
 King20 Stable
@@ -101,7 +103,7 @@ through lpp-link PE
 on Windows x86-64
 ```
 
-Until this gate passes, Windows continues to use the packaged `lpp_runtime.obj` plus MSVC linker fallback.
+Until that CI gate is green, Windows continues to use the packaged `lpp_runtime.obj` plus MSVC linker fallback for normal user builds.
 
 ## Design rule
 

--- a/src/bin/lpp-link.rs
+++ b/src/bin/lpp-link.rs
@@ -331,7 +331,9 @@ fn read_coff_input(path: &Path) -> Result<InputText, String> {
         if let SymbolSection::Section(index) = symbol.section() {
             if let Some(base) = section_base(index) {
                 if let Ok(name) = symbol.name() {
-                    if !name.is_empty() {
+                    // COFF emits local section symbols such as `.text$mn`.
+                    // They are relocation anchors, not linkable global names.
+                    if !name.is_empty() && !name.starts_with(".text") {
                         text_symbols.push((name.to_string(), base as u64 + symbol.address()));
                     }
                 }

--- a/src/bin/lpp-link.rs
+++ b/src/bin/lpp-link.rs
@@ -333,7 +333,7 @@ fn read_coff_input(path: &Path) -> Result<InputText, String> {
                 if let Ok(name) = symbol.name() {
                     // COFF emits local section symbols such as `.text$mn`.
                     // They are relocation anchors, not linkable global names.
-                    if !name.is_empty() && !name.starts_with(".text") {
+                    if !name.is_empty() && !name.starts_with(".text") && !name.starts_with('$') {
                         text_symbols.push((name.to_string(), base as u64 + symbol.address()));
                     }
                 }

--- a/src/bin/lpp-link.rs
+++ b/src/bin/lpp-link.rs
@@ -298,51 +298,24 @@ fn read_coff_input(path: &Path) -> Result<InputText, String> {
     if file.format() != BinaryFormat::Coff || file.architecture() != Architecture::X86_64 {
         return Err(format!("'{}' is not an x86-64 COFF object", path.display()));
     }
-
-    // MSVC often emits one COMDAT text section per function (`.text$mn`,
-    // `.text$...`) rather than one literal `.text`. Merge every text-kind
-    // section into the linker input while retaining per-section offsets.
-    let mut text = Vec::new();
-    let mut section_bases = Vec::new();
-    let mut section_relocations = Vec::new();
-    for section in file.sections() {
-        if section.kind() != object::SectionKind::Text {
-            continue;
-        }
-        let base = align_up(text.len(), 16);
-        text.resize(base, 0x90);
-        let index = section.index();
-        let data = section.uncompressed_data()
-            .map_err(|error| format!("read text from '{}': {error}", path.display()))?
-            .into_owned();
-        text.extend_from_slice(&data);
-        section_bases.push((index, base));
-        for (offset, relocation) in section.relocations() {
-            section_relocations.push((index, base, offset, relocation));
-        }
-    }
-    if section_bases.is_empty() {
-        return Err(format!("'{}' has no executable COFF text section", path.display()));
-    }
-    let section_base = |index| section_bases.iter().find(|(candidate, _)| *candidate == index).map(|(_, base)| *base);
-
+    let text_section = file.section_by_name(".text")
+        .ok_or_else(|| format!("'{}' has no .text section", path.display()))?;
+    let text_index = text_section.index();
+    let text = text_section.uncompressed_data()
+        .map_err(|error| format!("read .text from '{}': {error}", path.display()))?
+        .into_owned();
     let mut text_symbols = Vec::new();
     for symbol in file.symbols() {
-        if let SymbolSection::Section(index) = symbol.section() {
-            if let Some(base) = section_base(index) {
-                if let Ok(name) = symbol.name() {
-                    // COFF emits local section symbols such as `.text$mn`.
-                    // They are relocation anchors, not linkable global names.
-                    if !name.is_empty() && !name.starts_with(".text") && !name.starts_with('$') {
-                        text_symbols.push((name.to_string(), base as u64 + symbol.address()));
-                    }
+        if symbol.section() == SymbolSection::Section(text_index) {
+            if let Ok(name) = symbol.name() {
+                if !name.is_empty() {
+                    text_symbols.push((name.to_string(), symbol.address()));
                 }
             }
         }
     }
-
     let mut relocations = Vec::new();
-    for (_, base, offset, relocation) in section_relocations {
+    for (offset, relocation) in text_section.relocations() {
         let RelocationTarget::Symbol(symbol_index) = relocation.target() else {
             return Err(format!("'{}' has unsupported non-symbol relocation", path.display()));
         };
@@ -350,18 +323,13 @@ fn read_coff_input(path: &Path) -> Result<InputText, String> {
             .map_err(|error| format!("read relocation symbol: {error}"))?;
         let raw_name = symbol.name()
             .map_err(|error| format!("read relocation symbol name: {error}"))?;
-        let target = if raw_name.is_empty() {
-            match symbol.section() {
-                SymbolSection::Section(index) if section_base(index).is_some() => {
-                    format!("__coff_text_section_{}", section_base(index).unwrap())
-                }
-                _ => return Err(format!("'{}' has unresolved anonymous COFF relocation", path.display())),
-            }
+        let target = if raw_name.is_empty() && symbol.section() == SymbolSection::Section(text_index) {
+            "__self_text__".to_string()
         } else {
             raw_name.to_string()
         };
         relocations.push(Relocation {
-            offset: base + usize::try_from(offset).map_err(|_| "relocation offset overflow")?,
+            offset: usize::try_from(offset).map_err(|_| "relocation offset overflow")?,
             target,
             addend: relocation.addend(),
             size: relocation.size(),
@@ -385,52 +353,42 @@ fn pe_align(value: usize, alignment: usize) -> usize {
 /// Phase W2 PE MVP: merge runtime-free COFF `.text` sections into a console
 /// x86-64 PE executable. Runtime imports, data sections, and base relocations
 /// intentionally remain unsupported until W2 section/relocation coverage grows.
-fn build_kernel32_imports(
-    imports: &[String],
-    internal_refs: &[String],
-    section_rva: u32,
-) -> Result<(Vec<u8>, HashMap<String, u32>, HashMap<String, usize>), String> {
-    // descriptor + terminating descriptor; keep an .idata-like table even when
-    // only internal refptrs are present so code has a stable writable address.
+fn build_kernel32_imports(imports: &[String], section_rva: u32) -> Result<(Vec<u8>, HashMap<String, u32>), String> {
+    if imports.is_empty() {
+        return Ok((Vec::new(), HashMap::new()));
+    }
     let count = imports.len();
-    let descriptor_size = if count == 0 { 0 } else { 40usize };
+    let descriptor_size = 40usize; // descriptor + terminating zero descriptor
     let ilt_offset = align_up(descriptor_size, 8);
     let iat_offset = ilt_offset + (count + 1) * 8;
-    let refptr_offset = align_up(iat_offset + if count == 0 { 0 } else { (count + 1) * 8 }, 8);
-    let mut data = vec![0_u8; refptr_offset + internal_refs.len() * 8];
-    let mut iat_rvas = HashMap::new();
-    let mut refptr_offsets = HashMap::new();
-
-    if count != 0 {
-        let dll_offset = data.len();
-        data.extend_from_slice(b"KERNEL32.dll\0");
+    let dll_offset = iat_offset + (count + 1) * 8;
+    let mut data = vec![0_u8; dll_offset];
+    data.extend_from_slice(b"KERNEL32.dll\0");
+    while data.len() % 2 != 0 { data.push(0); }
+    let mut names = HashMap::new();
+    for import in imports {
+        let offset = data.len();
+        data.extend_from_slice(&[0, 0]); // hint
+        data.extend_from_slice(import.as_bytes());
+        data.push(0);
         while data.len() % 2 != 0 { data.push(0); }
-        let mut names = HashMap::new();
-        for import in imports {
-            let offset = data.len();
-            data.extend_from_slice(&[0, 0]); // hint
-            data.extend_from_slice(import.as_bytes());
-            data.push(0);
-            while data.len() % 2 != 0 { data.push(0); }
-            names.insert(import.clone(), offset);
-        }
-        for (index, import) in imports.iter().enumerate() {
-            let name_rva = section_rva + names[import] as u32;
-            let thunk = name_rva as u64;
-            let ilt = ilt_offset + index * 8;
-            let iat = iat_offset + index * 8;
-            data[ilt..ilt + 8].copy_from_slice(&thunk.to_le_bytes());
-            data[iat..iat + 8].copy_from_slice(&thunk.to_le_bytes());
-            iat_rvas.insert(format!("__imp_{import}"), section_rva + iat as u32);
-        }
-        put_u32(&mut data, 0, section_rva + ilt_offset as u32);
-        put_u32(&mut data, 12, section_rva + dll_offset as u32);
-        put_u32(&mut data, 16, section_rva + iat_offset as u32);
+        names.insert(import.clone(), offset);
     }
-    for (index, name) in internal_refs.iter().enumerate() {
-        refptr_offsets.insert(format!(".refptr.{name}"), refptr_offset + index * 8);
+    let mut iat_rvas = HashMap::new();
+    for (index, import) in imports.iter().enumerate() {
+        let name_rva = section_rva + names[import] as u32;
+        let thunk = name_rva as u64;
+        let ilt = ilt_offset + index * 8;
+        let iat = iat_offset + index * 8;
+        data[ilt..ilt + 8].copy_from_slice(&thunk.to_le_bytes());
+        data[iat..iat + 8].copy_from_slice(&thunk.to_le_bytes());
+        iat_rvas.insert(format!("__imp_{import}"), section_rva + iat as u32);
     }
-    Ok((data, iat_rvas, refptr_offsets))
+    // IMAGE_IMPORT_DESCRIPTOR for KERNEL32.dll.
+    put_u32(&mut data, 0, section_rva + ilt_offset as u32); // OriginalFirstThunk
+    put_u32(&mut data, 12, section_rva + dll_offset as u32); // Name
+    put_u32(&mut data, 16, section_rva + iat_offset as u32); // FirstThunk
+    Ok((data, iat_rvas))
 }
 
 /// Phase W2: merge x86-64 COFF text and emit a console PE32+ image. The
@@ -445,7 +403,6 @@ fn write_pe(inputs: &[PathBuf], output: &Path) -> Result<(), String> {
     let mut bases = Vec::new();
     let mut symbols: HashMap<String, u64> = HashMap::new();
     let mut imports = Vec::new();
-    let mut internal_refs = Vec::new();
     for input in &objects {
         let base = align_up(text.len(), 16);
         text.resize(base, 0x90);
@@ -460,9 +417,6 @@ fn write_pe(inputs: &[PathBuf], output: &Path) -> Result<(), String> {
             if relocation.target.starts_with("__imp_") {
                 let name = relocation.target.trim_start_matches("__imp_").to_string();
                 if !imports.contains(&name) { imports.push(name); }
-            } else if let Some(name) = relocation.target.strip_prefix(".refptr.") {
-                let name = name.to_string();
-                if !internal_refs.contains(&name) { internal_refs.push(name); }
             }
         }
         text.extend_from_slice(&input.text);
@@ -473,19 +427,8 @@ fn write_pe(inputs: &[PathBuf], output: &Path) -> Result<(), String> {
     let headers_size = PE_FILE_ALIGNMENT;
     let text_raw_size = pe_align(text.len(), PE_FILE_ALIGNMENT);
     let idata_rva = pe_align(PE_SECTION_RVA as usize + text.len(), PE_SECTION_ALIGNMENT) as u32;
-    let (mut idata, iat_rvas, refptr_offsets) = build_kernel32_imports(&imports, &internal_refs, idata_rva)?;
-    // Cranelift COFF emits .refptr.<symbol> variables for runtime function
-    // addresses. Populate those slots with fixed-base addresses in this MVP.
-    for (ref_name, offset) in &refptr_offsets {
-        let symbol_name = ref_name.trim_start_matches(".refptr.");
-        let target = *symbols.get(symbol_name).ok_or_else(|| {
-            format!("unresolved internal refptr symbol '{symbol_name}'")
-        })?;
-        let value = PE_IMAGE_BASE + PE_SECTION_RVA as u64 + target;
-        idata[*offset..*offset + 8].copy_from_slice(&value.to_le_bytes());
-    }
-    let has_kernel_imports = !imports.is_empty();
-    let has_idata = !idata.is_empty();
+    let (idata, iat_rvas) = build_kernel32_imports(&imports, idata_rva)?;
+    let has_imports = !idata.is_empty();
 
     for (index, input) in objects.iter().enumerate() {
         let base = bases[index];
@@ -495,12 +438,8 @@ fn write_pe(inputs: &[PathBuf], output: &Path) -> Result<(), String> {
             }
             let target_rva: u32 = if relocation.target == "__self_text__" {
                 PE_SECTION_RVA + base as u32
-            } else if let Some(offset) = relocation.target.strip_prefix("__coff_text_section_") {
-                PE_SECTION_RVA + offset.parse::<u32>().map_err(|_| "invalid COFF section relocation")?
             } else if let Some(rva) = iat_rvas.get(&relocation.target) {
                 *rva
-            } else if let Some(offset) = refptr_offsets.get(&relocation.target) {
-                idata_rva + *offset as u32
             } else {
                 PE_SECTION_RVA + *symbols.get(&relocation.target).ok_or_else(|| {
                     format!("'{}': unresolved external COFF symbol '{}'", input.path.display(), relocation.target)
@@ -527,10 +466,10 @@ fn write_pe(inputs: &[PathBuf], output: &Path) -> Result<(), String> {
         }
     }
 
-    let idata_raw_size = if has_idata { pe_align(idata.len(), PE_FILE_ALIGNMENT) } else { 0 };
+    let idata_raw_size = if has_imports { pe_align(idata.len(), PE_FILE_ALIGNMENT) } else { 0 };
     let idata_raw_offset = headers_size + text_raw_size;
-    let section_count = if has_idata { 2 } else { 1 };
-    let image_end = if has_idata {
+    let section_count = if has_imports { 2 } else { 1 };
+    let image_end = if has_imports {
         idata_rva as usize + idata.len()
     } else {
         PE_SECTION_RVA as usize + text.len()
@@ -564,7 +503,7 @@ fn write_pe(inputs: &[PathBuf], output: &Path) -> Result<(), String> {
     put_u64(&mut pe, opt + 88, 0x100000);
     put_u64(&mut pe, opt + 96, 0x1000);
     put_u32(&mut pe, opt + 108, 16);
-    if has_kernel_imports {
+    if has_imports {
         let directories = opt + 112;
         put_u32(&mut pe, directories + 8, idata_rva); // import table directory #1
         put_u32(&mut pe, directories + 12, 40);       // descriptor + terminator
@@ -579,7 +518,7 @@ fn write_pe(inputs: &[PathBuf], output: &Path) -> Result<(), String> {
     put_u32(&mut pe, section + 16, text_raw_size as u32);
     put_u32(&mut pe, section + 20, headers_size as u32);
     put_u32(&mut pe, section + 36, 0x60000020);
-    if has_idata {
+    if has_imports {
         let idata_section = section + 40;
         pe[idata_section..idata_section + 6].copy_from_slice(b".idata");
         put_u32(&mut pe, idata_section + 8, idata.len() as u32);
@@ -589,7 +528,7 @@ fn write_pe(inputs: &[PathBuf], output: &Path) -> Result<(), String> {
         put_u32(&mut pe, idata_section + 36, 0xC0000040);
     }
     pe[headers_size..headers_size + text.len()].copy_from_slice(&text);
-    if has_idata {
+    if has_imports {
         pe[idata_raw_offset..idata_raw_offset + idata.len()].copy_from_slice(&idata);
     }
     fs::write(output, pe).map_err(|error| format!("write '{}': {error}", output.display()))?;

--- a/src/bin/lpp-link.rs
+++ b/src/bin/lpp-link.rs
@@ -298,24 +298,49 @@ fn read_coff_input(path: &Path) -> Result<InputText, String> {
     if file.format() != BinaryFormat::Coff || file.architecture() != Architecture::X86_64 {
         return Err(format!("'{}' is not an x86-64 COFF object", path.display()));
     }
-    let text_section = file.section_by_name(".text")
-        .ok_or_else(|| format!("'{}' has no .text section", path.display()))?;
-    let text_index = text_section.index();
-    let text = text_section.uncompressed_data()
-        .map_err(|error| format!("read .text from '{}': {error}", path.display()))?
-        .into_owned();
+
+    // MSVC often emits one COMDAT text section per function (`.text$mn`,
+    // `.text$...`) rather than one literal `.text`. Merge every text-kind
+    // section into the linker input while retaining per-section offsets.
+    let mut text = Vec::new();
+    let mut section_bases = Vec::new();
+    let mut section_relocations = Vec::new();
+    for section in file.sections() {
+        if section.kind() != object::SectionKind::Text {
+            continue;
+        }
+        let base = align_up(text.len(), 16);
+        text.resize(base, 0x90);
+        let index = section.index();
+        let data = section.uncompressed_data()
+            .map_err(|error| format!("read text from '{}': {error}", path.display()))?
+            .into_owned();
+        text.extend_from_slice(&data);
+        section_bases.push((index, base));
+        for (offset, relocation) in section.relocations() {
+            section_relocations.push((index, base, offset, relocation));
+        }
+    }
+    if section_bases.is_empty() {
+        return Err(format!("'{}' has no executable COFF text section", path.display()));
+    }
+    let section_base = |index| section_bases.iter().find(|(candidate, _)| *candidate == index).map(|(_, base)| *base);
+
     let mut text_symbols = Vec::new();
     for symbol in file.symbols() {
-        if symbol.section() == SymbolSection::Section(text_index) {
-            if let Ok(name) = symbol.name() {
-                if !name.is_empty() {
-                    text_symbols.push((name.to_string(), symbol.address()));
+        if let SymbolSection::Section(index) = symbol.section() {
+            if let Some(base) = section_base(index) {
+                if let Ok(name) = symbol.name() {
+                    if !name.is_empty() {
+                        text_symbols.push((name.to_string(), base as u64 + symbol.address()));
+                    }
                 }
             }
         }
     }
+
     let mut relocations = Vec::new();
-    for (offset, relocation) in text_section.relocations() {
+    for (_, base, offset, relocation) in section_relocations {
         let RelocationTarget::Symbol(symbol_index) = relocation.target() else {
             return Err(format!("'{}' has unsupported non-symbol relocation", path.display()));
         };
@@ -323,13 +348,18 @@ fn read_coff_input(path: &Path) -> Result<InputText, String> {
             .map_err(|error| format!("read relocation symbol: {error}"))?;
         let raw_name = symbol.name()
             .map_err(|error| format!("read relocation symbol name: {error}"))?;
-        let target = if raw_name.is_empty() && symbol.section() == SymbolSection::Section(text_index) {
-            "__self_text__".to_string()
+        let target = if raw_name.is_empty() {
+            match symbol.section() {
+                SymbolSection::Section(index) if section_base(index).is_some() => {
+                    format!("__coff_text_section_{}", section_base(index).unwrap())
+                }
+                _ => return Err(format!("'{}' has unresolved anonymous COFF relocation", path.display())),
+            }
         } else {
             raw_name.to_string()
         };
         relocations.push(Relocation {
-            offset: usize::try_from(offset).map_err(|_| "relocation offset overflow")?,
+            offset: base + usize::try_from(offset).map_err(|_| "relocation offset overflow")?,
             target,
             addend: relocation.addend(),
             size: relocation.size(),
@@ -438,6 +468,8 @@ fn write_pe(inputs: &[PathBuf], output: &Path) -> Result<(), String> {
             }
             let target_rva: u32 = if relocation.target == "__self_text__" {
                 PE_SECTION_RVA + base as u32
+            } else if let Some(offset) = relocation.target.strip_prefix("__coff_text_section_") {
+                PE_SECTION_RVA + offset.parse::<u32>().map_err(|_| "invalid COFF section relocation")?
             } else if let Some(rva) = iat_rvas.get(&relocation.target) {
                 *rva
             } else {

--- a/src/bin/lpp-link.rs
+++ b/src/bin/lpp-link.rs
@@ -385,42 +385,52 @@ fn pe_align(value: usize, alignment: usize) -> usize {
 /// Phase W2 PE MVP: merge runtime-free COFF `.text` sections into a console
 /// x86-64 PE executable. Runtime imports, data sections, and base relocations
 /// intentionally remain unsupported until W2 section/relocation coverage grows.
-fn build_kernel32_imports(imports: &[String], section_rva: u32) -> Result<(Vec<u8>, HashMap<String, u32>), String> {
-    if imports.is_empty() {
-        return Ok((Vec::new(), HashMap::new()));
-    }
+fn build_kernel32_imports(
+    imports: &[String],
+    internal_refs: &[String],
+    section_rva: u32,
+) -> Result<(Vec<u8>, HashMap<String, u32>, HashMap<String, usize>), String> {
+    // descriptor + terminating descriptor; keep an .idata-like table even when
+    // only internal refptrs are present so code has a stable writable address.
     let count = imports.len();
-    let descriptor_size = 40usize; // descriptor + terminating zero descriptor
+    let descriptor_size = if count == 0 { 0 } else { 40usize };
     let ilt_offset = align_up(descriptor_size, 8);
     let iat_offset = ilt_offset + (count + 1) * 8;
-    let dll_offset = iat_offset + (count + 1) * 8;
-    let mut data = vec![0_u8; dll_offset];
-    data.extend_from_slice(b"KERNEL32.dll\0");
-    while data.len() % 2 != 0 { data.push(0); }
-    let mut names = HashMap::new();
-    for import in imports {
-        let offset = data.len();
-        data.extend_from_slice(&[0, 0]); // hint
-        data.extend_from_slice(import.as_bytes());
-        data.push(0);
-        while data.len() % 2 != 0 { data.push(0); }
-        names.insert(import.clone(), offset);
-    }
+    let refptr_offset = align_up(iat_offset + if count == 0 { 0 } else { (count + 1) * 8 }, 8);
+    let mut data = vec![0_u8; refptr_offset + internal_refs.len() * 8];
     let mut iat_rvas = HashMap::new();
-    for (index, import) in imports.iter().enumerate() {
-        let name_rva = section_rva + names[import] as u32;
-        let thunk = name_rva as u64;
-        let ilt = ilt_offset + index * 8;
-        let iat = iat_offset + index * 8;
-        data[ilt..ilt + 8].copy_from_slice(&thunk.to_le_bytes());
-        data[iat..iat + 8].copy_from_slice(&thunk.to_le_bytes());
-        iat_rvas.insert(format!("__imp_{import}"), section_rva + iat as u32);
+    let mut refptr_offsets = HashMap::new();
+
+    if count != 0 {
+        let dll_offset = data.len();
+        data.extend_from_slice(b"KERNEL32.dll\0");
+        while data.len() % 2 != 0 { data.push(0); }
+        let mut names = HashMap::new();
+        for import in imports {
+            let offset = data.len();
+            data.extend_from_slice(&[0, 0]); // hint
+            data.extend_from_slice(import.as_bytes());
+            data.push(0);
+            while data.len() % 2 != 0 { data.push(0); }
+            names.insert(import.clone(), offset);
+        }
+        for (index, import) in imports.iter().enumerate() {
+            let name_rva = section_rva + names[import] as u32;
+            let thunk = name_rva as u64;
+            let ilt = ilt_offset + index * 8;
+            let iat = iat_offset + index * 8;
+            data[ilt..ilt + 8].copy_from_slice(&thunk.to_le_bytes());
+            data[iat..iat + 8].copy_from_slice(&thunk.to_le_bytes());
+            iat_rvas.insert(format!("__imp_{import}"), section_rva + iat as u32);
+        }
+        put_u32(&mut data, 0, section_rva + ilt_offset as u32);
+        put_u32(&mut data, 12, section_rva + dll_offset as u32);
+        put_u32(&mut data, 16, section_rva + iat_offset as u32);
     }
-    // IMAGE_IMPORT_DESCRIPTOR for KERNEL32.dll.
-    put_u32(&mut data, 0, section_rva + ilt_offset as u32); // OriginalFirstThunk
-    put_u32(&mut data, 12, section_rva + dll_offset as u32); // Name
-    put_u32(&mut data, 16, section_rva + iat_offset as u32); // FirstThunk
-    Ok((data, iat_rvas))
+    for (index, name) in internal_refs.iter().enumerate() {
+        refptr_offsets.insert(format!(".refptr.{name}"), refptr_offset + index * 8);
+    }
+    Ok((data, iat_rvas, refptr_offsets))
 }
 
 /// Phase W2: merge x86-64 COFF text and emit a console PE32+ image. The
@@ -435,6 +445,7 @@ fn write_pe(inputs: &[PathBuf], output: &Path) -> Result<(), String> {
     let mut bases = Vec::new();
     let mut symbols: HashMap<String, u64> = HashMap::new();
     let mut imports = Vec::new();
+    let mut internal_refs = Vec::new();
     for input in &objects {
         let base = align_up(text.len(), 16);
         text.resize(base, 0x90);
@@ -449,6 +460,9 @@ fn write_pe(inputs: &[PathBuf], output: &Path) -> Result<(), String> {
             if relocation.target.starts_with("__imp_") {
                 let name = relocation.target.trim_start_matches("__imp_").to_string();
                 if !imports.contains(&name) { imports.push(name); }
+            } else if let Some(name) = relocation.target.strip_prefix(".refptr.") {
+                let name = name.to_string();
+                if !internal_refs.contains(&name) { internal_refs.push(name); }
             }
         }
         text.extend_from_slice(&input.text);
@@ -459,8 +473,19 @@ fn write_pe(inputs: &[PathBuf], output: &Path) -> Result<(), String> {
     let headers_size = PE_FILE_ALIGNMENT;
     let text_raw_size = pe_align(text.len(), PE_FILE_ALIGNMENT);
     let idata_rva = pe_align(PE_SECTION_RVA as usize + text.len(), PE_SECTION_ALIGNMENT) as u32;
-    let (idata, iat_rvas) = build_kernel32_imports(&imports, idata_rva)?;
-    let has_imports = !idata.is_empty();
+    let (mut idata, iat_rvas, refptr_offsets) = build_kernel32_imports(&imports, &internal_refs, idata_rva)?;
+    // Cranelift COFF emits .refptr.<symbol> variables for runtime function
+    // addresses. Populate those slots with fixed-base addresses in this MVP.
+    for (ref_name, offset) in &refptr_offsets {
+        let symbol_name = ref_name.trim_start_matches(".refptr.");
+        let target = *symbols.get(symbol_name).ok_or_else(|| {
+            format!("unresolved internal refptr symbol '{symbol_name}'")
+        })?;
+        let value = PE_IMAGE_BASE + PE_SECTION_RVA as u64 + target;
+        idata[*offset..*offset + 8].copy_from_slice(&value.to_le_bytes());
+    }
+    let has_kernel_imports = !imports.is_empty();
+    let has_idata = !idata.is_empty();
 
     for (index, input) in objects.iter().enumerate() {
         let base = bases[index];
@@ -474,6 +499,8 @@ fn write_pe(inputs: &[PathBuf], output: &Path) -> Result<(), String> {
                 PE_SECTION_RVA + offset.parse::<u32>().map_err(|_| "invalid COFF section relocation")?
             } else if let Some(rva) = iat_rvas.get(&relocation.target) {
                 *rva
+            } else if let Some(offset) = refptr_offsets.get(&relocation.target) {
+                idata_rva + *offset as u32
             } else {
                 PE_SECTION_RVA + *symbols.get(&relocation.target).ok_or_else(|| {
                     format!("'{}': unresolved external COFF symbol '{}'", input.path.display(), relocation.target)
@@ -500,10 +527,10 @@ fn write_pe(inputs: &[PathBuf], output: &Path) -> Result<(), String> {
         }
     }
 
-    let idata_raw_size = if has_imports { pe_align(idata.len(), PE_FILE_ALIGNMENT) } else { 0 };
+    let idata_raw_size = if has_idata { pe_align(idata.len(), PE_FILE_ALIGNMENT) } else { 0 };
     let idata_raw_offset = headers_size + text_raw_size;
-    let section_count = if has_imports { 2 } else { 1 };
-    let image_end = if has_imports {
+    let section_count = if has_idata { 2 } else { 1 };
+    let image_end = if has_idata {
         idata_rva as usize + idata.len()
     } else {
         PE_SECTION_RVA as usize + text.len()
@@ -537,7 +564,7 @@ fn write_pe(inputs: &[PathBuf], output: &Path) -> Result<(), String> {
     put_u64(&mut pe, opt + 88, 0x100000);
     put_u64(&mut pe, opt + 96, 0x1000);
     put_u32(&mut pe, opt + 108, 16);
-    if has_imports {
+    if has_kernel_imports {
         let directories = opt + 112;
         put_u32(&mut pe, directories + 8, idata_rva); // import table directory #1
         put_u32(&mut pe, directories + 12, 40);       // descriptor + terminator
@@ -552,7 +579,7 @@ fn write_pe(inputs: &[PathBuf], output: &Path) -> Result<(), String> {
     put_u32(&mut pe, section + 16, text_raw_size as u32);
     put_u32(&mut pe, section + 20, headers_size as u32);
     put_u32(&mut pe, section + 36, 0x60000020);
-    if has_imports {
+    if has_idata {
         let idata_section = section + 40;
         pe[idata_section..idata_section + 6].copy_from_slice(b".idata");
         put_u32(&mut pe, idata_section + 8, idata.len() as u32);
@@ -562,7 +589,7 @@ fn write_pe(inputs: &[PathBuf], output: &Path) -> Result<(), String> {
         put_u32(&mut pe, idata_section + 36, 0xC0000040);
     }
     pe[headers_size..headers_size + text.len()].copy_from_slice(&text);
-    if has_imports {
+    if has_idata {
         pe[idata_raw_offset..idata_raw_offset + idata.len()].copy_from_slice(&idata);
     }
     fs::write(output, pe).map_err(|error| format!("write '{}': {error}", output.display()))?;

--- a/tests/test_direct_pe_king20.ps1
+++ b/tests/test_direct_pe_king20.ps1
@@ -1,0 +1,62 @@
+# King20 direct PE gate. Run only after VSCMD_BAT is supplied by Windows CI.
+$ErrorActionPreference = "Stop"
+
+$Root = Split-Path -Parent $PSScriptRoot
+$Lpp = Join-Path $Root "target\release\lpp.exe"
+$Linker = Join-Path $Root "target\release\lpp-link.exe"
+$Work = Join-Path $env:RUNNER_TEMP "lpp-king20-direct-pe"
+New-Item -ItemType Directory -Force $Work | Out-Null
+
+$cases = @(
+    @("benchmarks\bench_fib.lpp", "9227465"),
+    @("benchmarks\bench_loop.lpp", "49999995000000"),
+    @("benchmarks\bench_calls.lpp", "500000500000"),
+    @("tests\arith.lpp", "15`n5`n50`n2"),
+    @("tests\branches.lpp", "1`n0`n1"),
+    @("tests\nested_calls.lpp", "120"),
+    @("tests\closure_test.lpp", "52"),
+    @("tests\list_safety.lpp", "3`n5`n13"),
+    @("tests\owned_return.lpp", "1"),
+    @("tests\arc_branch_return.lpp", "1"),
+    @("tests\arc_nested_struct.lpp", "1"),
+    @("tests\arc_direct_alias.lpp", "1"),
+    @("tests\arc_closure_capture.lpp", "0"),
+    @("tests\arc_borrowed_return.lpp", "1"),
+    @("tests\arc_borrowed_field_return.lpp", "1"),
+    @("tests\arc_field_alias.lpp", "1"),
+    @("tests\arc_list_alias.lpp", "7"),
+    @("tests\arc_list_custom.lpp", "1"),
+    @("tests\arc_nested_branch_alias.lpp", "1"),
+    @("tests\arc_closure_branch_capture.lpp", "0")
+)
+
+$cmd = Join-Path $Work "build_runtime.cmd"
+@"
+@echo off
+call "%VSCMD_BAT%" >nul || exit /b 1
+cl.exe /nologo /O2 /GS- /c "$Root\runtime\windows_x86_64_min.c" "/Fo:$Work\lpp_runtime_min.obj" || exit /b 1
+exit /b 0
+"@ | Set-Content -Path $cmd -Encoding ascii
+cmd.exe /d /c $cmd
+if ($LASTEXITCODE -ne 0) { throw "Failed to compile direct PE runtime" }
+
+$index = 0
+foreach ($case in $cases) {
+    $index++
+    $source = Join-Path $Root $case[0]
+    $copied = Join-Path $Work ("{0:D2}.lpp" -f $index)
+    Copy-Item $source $copied -Force
+    $env:LPP_AOT = "1"
+    & $Lpp $copied | Out-Null
+    if ($LASTEXITCODE -ne 0) { throw "AOT compile failed for $($case[0])" }
+    $exe = Join-Path $Work ("{0:D2}.exe" -f $index)
+    & $Linker pe ($copied.Replace(".lpp", ".o")) "$Work\lpp_runtime_min.obj" -o $exe
+    if ($LASTEXITCODE -ne 0) { throw "Direct PE link failed for $($case[0])" }
+    $actual = (& $exe | ForEach-Object { $_.Trim() }) -join "`n"
+    if ($LASTEXITCODE -ne 0 -or $actual -ne $case[1]) {
+        throw "King20 PE mismatch for $($case[0]): expected '$($case[1])', got '$actual'"
+    }
+    Write-Host "PASS direct PE $index/20 $($case[0])"
+}
+
+Write-Host "PASS King20 direct PE: 20/20"


### PR DESCRIPTION
## Summary

- merges the Kernel32 PE import runtime, COFF COMDAT merge handling, and direct PE King20 validation into one Windows branch
- adds Windows CI gate that compiles the freestanding runtime, direct-links PE, and checks all 20 King20 cases

## Scope

This is the direct PE runtime/King20 gate. If green, it proves the verified Windows direct-link subset. Writable data, broader PE relocation support, and non-Kernel32 runtime features remain separate follow-ups.

## Verification

- Rust unit tests pass on Linux
- Windows CI is authoritative for COFF/PE execution