### PR TITLE
Add Rust-free release installers and release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,90 @@
+name: Release L++
+
+on:
+  push:
+    tags: ["v*"]
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Release tag, for example v0.1.0"
+        required: true
+        type: string
+
+permissions:
+  contents: write
+
+jobs:
+  linux-x86_64:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - uses: dtolnay/rust-toolchain@stable
+      - name: Build compiler and direct linker
+        run: cargo build --release --locked --bin lpp --bin lpp-link
+      - name: Package Linux runtime objects
+        run: |
+          mkdir -p package/lpp-linux-x86_64/bin package/lpp-linux-x86_64/lib
+          cp target/release/lpp package/lpp-linux-x86_64/bin/
+          cp target/release/lpp-link package/lpp-linux-x86_64/bin/
+          cc -O2 -fPIC -c lpp_runtime.c -o package/lpp-linux-x86_64/lib/lpp_runtime.o -pthread
+          cc -O2 -ffreestanding -fno-stack-protector -fno-pic -mno-red-zone \
+            -c runtime/linux_x86_64_min.c -o package/lpp-linux-x86_64/lib/lpp_runtime_min.o
+          cp lpp_runtime.c package/lpp-linux-x86_64/lib/
+          tar -C package -czf lpp-linux-x86_64.tar.gz lpp-linux-x86_64
+      - uses: actions/upload-artifact@v4
+        with:
+          name: lpp-linux-x86_64
+          path: lpp-linux-x86_64.tar.gz
+
+  windows-x86_64:
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v5
+      - uses: dtolnay/rust-toolchain@stable
+      - name: Locate MSVC tools
+        shell: pwsh
+        run: |
+          $vswhere = Join-Path ${env:ProgramFiles(x86)} "Microsoft Visual Studio\Installer\vswhere.exe"
+          $vs = & $vswhere -latest -products * -requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64 -property installationPath
+          if (-not $vs) { throw "Visual Studio C++ tools were not found" }
+          "VSCMD_BAT=$vs\VC\Auxiliary\Build\vcvars64.bat" | Out-File -FilePath $env:GITHUB_ENV -Append
+      - name: Build and package Windows release
+        shell: pwsh
+        run: |
+          cargo build --release --locked --bin lpp --bin lpp-link
+          $root = Join-Path $env:RUNNER_TEMP "lpp-windows-x86_64"
+          New-Item -ItemType Directory -Force "$root\bin", "$root\lib" | Out-Null
+          Copy-Item target\release\lpp.exe "$root\bin\lpp.exe"
+          Copy-Item target\release\lpp-link.exe "$root\bin\lpp-link.exe"
+          $cmd = Join-Path $env:RUNNER_TEMP "package-runtime.cmd"
+          @"
+          @echo off
+          call "%VSCMD_BAT%" >nul || exit /b 1
+          cl.exe /nologo /O2 /c lpp_runtime.c "/Fo:$root\lib\lpp_runtime.obj" || exit /b 1
+          cl.exe /nologo /O2 /GS- /c runtime\windows_x86_64_min.c "/Fo:$root\lib\lpp_runtime_min.obj" || exit /b 1
+          exit /b 0
+          "@ | Set-Content -Path $cmd -Encoding ascii
+          cmd.exe /d /c $cmd
+          if ($LASTEXITCODE -ne 0) { throw "Runtime object packaging failed" }
+          Copy-Item lpp_runtime.c "$root\lib\lpp_runtime.c"
+          Compress-Archive -Path $root -DestinationPath lpp-windows-x86_64.zip -Force
+      - uses: actions/upload-artifact@v4
+        with:
+          name: lpp-windows-x86_64
+          path: lpp-windows-x86_64.zip
+
+  publish:
+    needs: [linux-x86_64, windows-x86_64]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          path: artifacts
+      - name: Create GitHub release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ github.event_name == 'workflow_dispatch' && inputs.tag || github.ref_name }}
+          generate_release_notes: true
+          files: |
+            artifacts/lpp-linux-x86_64/lpp-linux-x86_64.tar.gz
+            artifacts/lpp-windows-x86_64/lpp-windows-x86_64.zip

--- a/README.md
+++ b/README.md
@@ -215,15 +215,26 @@ Global recognition depends on GitHub Linguist maintainers accepting the upstream
 
 ## Getting started
 
-### Install
+### Install a release — Rust not required
+
+The default installers download a matching release bundle containing `lpp`, `lpp-link`, and packaged runtime objects. End users do **not** need Rust/Cargo for normal installation.
 
 ```bash
-# Linux / macOS shell
-./install.sh
+# Linux x86-64
+curl -fsSL https://raw.githubusercontent.com/samarnever-droid/lplusplus/master/install.sh | sh
 
 # Windows PowerShell
-./install.ps1
+irm https://raw.githubusercontent.com/samarnever-droid/lplusplus/master/install.ps1 | iex
 ```
+
+To build locally from a source checkout instead:
+
+```bash
+LPP_FROM_SOURCE=1 ./install.sh
+# PowerShell: $env:LPP_FROM_SOURCE=1; .\install.ps1
+```
+
+Release bundles currently target Linux x86-64 and Windows x86-64. macOS remains a source-build / future Mach-O target.
 
 ### Command model: files vs packages
 

--- a/install.ps1
+++ b/install.ps1
@@ -1,71 +1,73 @@
 <#
 .SYNOPSIS
-    Installs the L++ compiler and runtime assets to a per-user directory.
-
-.DESCRIPTION
-    Builds the release compiler, copies `lpp.exe` and `lpp_runtime.c` into
-    `$HOME\.lpp`, and optionally precompiles `lpp_runtime.obj` when MSVC is
-    available. The installed `lpp.exe` is the primary CLI entrypoint.
-
-.EXAMPLE
-    .\install.ps1
+Installs a prebuilt L++ release on Windows. Use `$env:LPP_FROM_SOURCE=1` to build from a local source checkout.
 #>
 
 $ErrorActionPreference = "Stop"
-
 $ProjectDir = $PSScriptRoot
 $InstallDir = if ($env:LPP_INSTALL_DIR) { $env:LPP_INSTALL_DIR } else { Join-Path $HOME ".lpp" }
 $BinDir = Join-Path $InstallDir "bin"
 $LibDir = Join-Path $InstallDir "lib"
-$CompilerSource = Join-Path $ProjectDir "target\release\lpp.exe"
-$CompilerDest = Join-Path $BinDir "lpp.exe"
-$RuntimeSource = Join-Path $ProjectDir "lpp_runtime.c"
-$RuntimeObject = Join-Path $LibDir "lpp_runtime.obj"
+$Version = if ($env:LPP_VERSION) { $env:LPP_VERSION } else { "v0.1.0" }
+$ReleaseUrl = "https://github.com/samarnever-droid/lplusplus/releases/download/$Version/lpp-windows-x86_64.zip"
 
-Write-Host "========================================================" -ForegroundColor Cyan
-Write-Host "                 L++ GLOBAL INSTALLER                   " -ForegroundColor Cyan
-Write-Host "========================================================" -ForegroundColor Cyan
+New-Item -ItemType Directory -Force $BinDir, $LibDir | Out-Null
 
-Write-Host "`n[1/4] Building release compiler and linker MVP..." -ForegroundColor Yellow
-$proc = Start-Process -FilePath "cargo" -ArgumentList "build --release --bin lpp --bin lpp-link" -WorkingDirectory $ProjectDir -NoNewWindow -Wait -PassThru
-if ($proc.ExitCode -ne 0) {
-    Write-Error "Cargo build failed. Make sure Rust is installed and cargo is on PATH."
-    exit 1
+function Install-Release {
+    $temp = Join-Path $env:TEMP "lpp-release-$([guid]::NewGuid())"
+    New-Item -ItemType Directory -Force $temp | Out-Null
+    try {
+        Write-Host "[1/3] Downloading L++ $Version release..." -ForegroundColor Yellow
+        Invoke-WebRequest -Uri $ReleaseUrl -OutFile "$temp\lpp.zip" -UseBasicParsing
+        Expand-Archive -Path "$temp\lpp.zip" -DestinationPath $temp -Force
+        $root = Join-Path $temp "lpp-windows-x86_64"
+        if (-not (Test-Path "$root\bin\lpp.exe")) { throw "Release archive is missing lpp.exe" }
+        Write-Host "[2/3] Installing compiler, linker, and runtime objects..." -ForegroundColor Yellow
+        Copy-Item "$root\bin\lpp.exe" "$BinDir\lpp.exe" -Force
+        Copy-Item "$root\bin\lpp-link.exe" "$BinDir\lpp-link.exe" -Force
+        Copy-Item "$root\lib\*" $LibDir -Force
+        return $true
+    } catch {
+        Write-Warning "Release installation failed: $($_.Exception.Message)"
+        return $false
+    } finally {
+        Remove-Item $temp -Recurse -Force -ErrorAction SilentlyContinue
+    }
 }
 
-Write-Host "`n[2/4] Preparing install directories..." -ForegroundColor Yellow
-New-Item -ItemType Directory -Force $BinDir | Out-Null
-New-Item -ItemType Directory -Force $LibDir | Out-Null
-
-Write-Host "`n[3/4] Installing compiler and runtime files..." -ForegroundColor Yellow
-Copy-Item -Path $CompilerSource -Destination $CompilerDest -Force
-$LinkerSource = Join-Path $ProjectDir "target\release\lpp-link.exe"
-if (Test-Path $LinkerSource) {
-    Copy-Item -Path $LinkerSource -Destination (Join-Path $BinDir "lpp-link.exe") -Force
+function Install-Source {
+    if (-not (Get-Command cargo -ErrorAction SilentlyContinue)) {
+        throw "Cargo is required for source installation. Install Rust or use a published release asset."
+    }
+    Write-Host "[1/3] Building L++ compiler and linker from source..." -ForegroundColor Yellow
+    cargo build --release --bin lpp --bin lpp-link
+    if ($LASTEXITCODE -ne 0) { throw "Cargo build failed." }
+    Write-Host "[2/3] Packaging compiler and runtime objects..." -ForegroundColor Yellow
+    Copy-Item "$ProjectDir\target\release\lpp.exe" "$BinDir\lpp.exe" -Force
+    Copy-Item "$ProjectDir\target\release\lpp-link.exe" "$BinDir\lpp-link.exe" -Force
+    Copy-Item "$ProjectDir\lpp_runtime.c" "$LibDir\lpp_runtime.c" -Force
+    $vswhere = Join-Path ${env:ProgramFiles(x86)} "Microsoft Visual Studio\Installer\vswhere.exe"
+    if (Test-Path $vswhere) {
+        $vs = & $vswhere -latest -products * -requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64 -property installationPath
+        if ($vs) {
+            cmd.exe /d /c "call `"$vs\VC\Auxiliary\Build\vcvars64.bat`" >nul && cl.exe /nologo /O2 /c `"$ProjectDir\lpp_runtime.c`" /Fo:`"$LibDir\lpp_runtime.obj`""
+            cmd.exe /d /c "call `"$vs\VC\Auxiliary\Build\vcvars64.bat`" >nul && cl.exe /nologo /O2 /GS- /c `"$ProjectDir\runtime\windows_x86_64_min.c`" /Fo:`"$LibDir\lpp_runtime_min.obj`""
+        }
+    }
 }
-Copy-Item -Path $RuntimeSource -Destination (Join-Path $LibDir "lpp_runtime.c") -Force
 
-if (Get-Command cl.exe -ErrorAction SilentlyContinue) {
-    Write-Host "  Precompiling runtime object with cl.exe..." -ForegroundColor Yellow
-    & cl.exe /nologo /O2 /c (Join-Path $LibDir "lpp_runtime.c") "/Fo:$RuntimeObject" 2>&1 | Out-Null
-} else {
-    Write-Host "  MSVC not detected. Native builds will compile lpp_runtime.c at link time." -ForegroundColor DarkYellow
+if ($env:LPP_FROM_SOURCE -eq "1") {
+    Install-Source
+} elseif (-not (Install-Release)) {
+    Write-Warning "Falling back to local source installation."
+    Install-Source
 }
 
-Write-Host "`n[4/4] Updating PATH guidance..." -ForegroundColor Yellow
 $registryKey = [Microsoft.Win32.Registry]::CurrentUser.OpenSubKey("Environment", $true)
 $currentPath = $registryKey.GetValue("Path", "", [Microsoft.Win32.RegistryValueOptions]::DoNotExpandEnvironmentNames)
-
 if ($currentPath -split ";" -notcontains $BinDir) {
-    $newPath = ($currentPath + ";" + $BinDir) -replace ";+", ";"
-    $registryKey.SetValue("Path", $newPath, [Microsoft.Win32.RegistryValueKind]::String)
-    Write-Host "  Added $BinDir to Current User PATH." -ForegroundColor Green
-    Write-Host "  Restart your terminal to pick up the PATH change." -ForegroundColor Green
-} else {
-    Write-Host "  $BinDir is already present in Current User PATH." -ForegroundColor Green
+    $registryKey.SetValue("Path", ($currentPath + ";" + $BinDir) -replace ";+", ";", [Microsoft.Win32.RegistryValueKind]::String)
 }
 $registryKey.Close()
-
-Write-Host "`n========================================================" -ForegroundColor Green
-Write-Host "       L++ INSTALLED. TRY: lpp.exe -h OR lpp -h         " -ForegroundColor Green
-Write-Host "========================================================" -ForegroundColor Green
+Write-Host "[3/3] Installed commands: lpp, lpp-link" -ForegroundColor Green
+Write-Host "Restart your terminal, then run: lpp -h" -ForegroundColor Green

--- a/install.sh
+++ b/install.sh
@@ -5,38 +5,64 @@ PROJECT_DIR=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
 INSTALL_DIR=${LPP_INSTALL_DIR:-"$HOME/.lpp"}
 BIN_DIR="$INSTALL_DIR/bin"
 LIB_DIR="$INSTALL_DIR/lib"
+VERSION=${LPP_VERSION:-v0.1.0}
+RELEASE_URL="https://github.com/samarnever-droid/lplusplus/releases/download/$VERSION/lpp-linux-x86_64.tar.gz"
 
 printf '%s\n' "========================================================"
 printf '%s\n' "                 L++ GLOBAL INSTALLER                   "
 printf '%s\n' "========================================================"
 
-printf '\n%s\n' "[1/4] Building release compiler and ELF linker MVP..."
-(cd "$PROJECT_DIR" && cargo build --release --bin lpp --bin lpp-link)
-
-printf '\n%s\n' "[2/4] Preparing install directories..."
 mkdir -p "$BIN_DIR" "$LIB_DIR"
 
-printf '\n%s\n' "[3/4] Installing compiler and runtime files..."
-cp "$PROJECT_DIR/target/release/lpp" "$BIN_DIR/lpp"
-if [ -f "$PROJECT_DIR/target/release/lpp-link" ]; then
+install_release() {
+    command -v curl >/dev/null 2>&1 || return 1
+    command -v tar >/dev/null 2>&1 || return 1
+    temp=$(mktemp -d "${TMPDIR:-/tmp}/lpp-release.XXXXXX")
+    trap 'rm -rf "$temp"' EXIT HUP INT TERM
+    printf '%s\n' "[1/3] Downloading L++ $VERSION release..."
+    if ! curl -fsSL "$RELEASE_URL" -o "$temp/lpp.tar.gz"; then
+        return 1
+    fi
+    tar -xzf "$temp/lpp.tar.gz" -C "$temp"
+    root="$temp/lpp-linux-x86_64"
+    [ -x "$root/bin/lpp" ] || return 1
+    printf '%s\n' "[2/3] Installing compiler, linker, and packaged runtimes..."
+    cp "$root/bin/lpp" "$BIN_DIR/lpp"
+    cp "$root/bin/lpp-link" "$BIN_DIR/lpp-link"
+    cp "$root/lib/"* "$LIB_DIR/"
+    rm -rf "$temp"
+    trap - EXIT HUP INT TERM
+    return 0
+}
+
+install_source() {
+    command -v cargo >/dev/null 2>&1 || {
+        printf '%s\n' "Rust/Cargo is required for source installation. Use the release installer path or install Rust." >&2
+        exit 1
+    }
+    printf '%s\n' "[1/3] Building L++ compiler and linker from source..."
+    (cd "$PROJECT_DIR" && cargo build --release --bin lpp --bin lpp-link)
+    printf '%s\n' "[2/3] Packaging local compiler and runtime objects..."
+    cp "$PROJECT_DIR/target/release/lpp" "$BIN_DIR/lpp"
     cp "$PROJECT_DIR/target/release/lpp-link" "$BIN_DIR/lpp-link"
-fi
-cp "$PROJECT_DIR/lpp_runtime.c" "$LIB_DIR/lpp_runtime.c"
+    cp "$PROJECT_DIR/lpp_runtime.c" "$LIB_DIR/lpp_runtime.c"
+    if command -v cc >/dev/null 2>&1; then
+        cc -O2 -fPIC -c "$LIB_DIR/lpp_runtime.c" -o "$LIB_DIR/lpp_runtime.o"
+        cc -O2 -ffreestanding -fno-stack-protector -fno-pic -mno-red-zone \
+            -c "$PROJECT_DIR/runtime/linux_x86_64_min.c" -o "$LIB_DIR/lpp_runtime_min.o" || true
+    fi
+}
 
-if command -v cc >/dev/null 2>&1; then
-    printf '%s\n' "  Packaging prebuilt runtime object with cc..."
-    cc -O2 -fPIC -c "$LIB_DIR/lpp_runtime.c" -o "$LIB_DIR/lpp_runtime.o"
-    cc -O2 -ffreestanding -fno-stack-protector -fno-pic -mno-red-zone \
-        -c "$PROJECT_DIR/runtime/linux_x86_64_min.c" -o "$LIB_DIR/lpp_runtime_min.o" || true
-    printf '%s\n' "  Normal lpp builds will link this object without recompiling lpp_runtime.c."
+if [ "${LPP_FROM_SOURCE:-0}" = "1" ]; then
+    install_source
+elif install_release; then
+    printf '%s\n' "[3/3] Release installation complete."
 else
-    printf '%s\n' "  cc not found: runtime source fallback will be used by native builds."
+    printf '%s\n' "Release asset unavailable; falling back to local source installation." >&2
+    install_source
+    printf '%s\n' "[3/3] Source installation complete."
 fi
 
-printf '\n%s\n' "[4/4] PATH guidance..."
 printf '%s\n' "  Add this to your shell profile if needed:"
 printf '  export PATH="%s:$PATH"\n' "$BIN_DIR"
-
-printf '\n%s\n' "========================================================"
-printf '%s\n' "             L++ INSTALLED. TRY: lpp -h                 "
-printf '%s\n' "========================================================"
+printf '%s\n' "Installed commands: lpp, lpp-link"


### PR DESCRIPTION
## Summary

- adds Linux and Windows release asset workflow
- packages lpp, lpp-link, full runtime object, and direct runtime object
- changes installers to download a release bundle by default
- retains `LPP_FROM_SOURCE=1` for source/Cargo installs
- documents that normal users do not need Rust

## Release artifacts

- `lpp-linux-x86_64.tar.gz`
- `lpp-windows-x86_64.zip`

## Verification

- `sh -n install.sh`
- CI release workflow will build both platform artifacts on tag or manual dispatch.