### PR TITLE
Prepare v0.1.1 release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -250,7 +250,7 @@ checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
 
 [[package]]
 name = "lpp"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "cranelift-codegen",
  "cranelift-frontend",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lpp"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2024"
 
 [dependencies]

--- a/src/main.rs
+++ b/src/main.rs
@@ -66,7 +66,7 @@ fn main() {
     
     for arg in args.iter().skip(1) {
         if arg == "--version" || arg == "-v" {
-            println!("L++ Compiler v0.1.0");
+            println!("L++ Compiler v0.1.1");
             return;
         } else if arg == "--help" || arg == "-h" {
             println!("L++ (L Plus Plus) Compiler, Codegen Backend & Package Manager");
@@ -291,7 +291,7 @@ fn main() {
                 println!("TIMING_JSON: {{\"io\": {}, \"lex\": {}, \"parse\": {}, \"semantic\": {}, \"typecheck\": {}, \"escape\": {}, \"mir\": {}, \"aot\": {}, \"total\": {}}}", 
                    io_time.as_secs_f64(), lex_time.as_secs_f64(), parse_time.as_secs_f64(), sem_time.as_secs_f64(), ty_time.as_secs_f64(), esc_time.as_secs_f64(), mir_time.as_secs_f64(), aot_time.as_secs_f64(), total_time.as_secs_f64());
             } else if !dump_ast && !dump_symbols && !dump_types && !dump_escape && !dump_mir && !dump_c {
-                println!("L++ v0.1.0\n");
+                println!("L++ v0.1.1\n");
                 if explicit_emit {
                     println!("Artifacts emitted next to the source file.");
                 } else {


### PR DESCRIPTION
## Summary

- bumps L++ package and CLI version to v0.1.1
- prepares the Rust-free release installer workflow for published Linux and Windows bundles

## Verification

Release workflow will build both platform artifacts after the v0.1.1 tag is pushed.