### PR TITLE
Add macOS release packaging and CI validation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: dtolnay/rust-toolchain@stable
       - name: Show toolchain
         run: |
@@ -43,7 +43,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 25
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: dtolnay/rust-toolchain@stable
       - name: Run King 20 Stable v1
         run: python3 benchmarks/king20/run.py --suite stable
@@ -67,7 +67,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 25
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: dtolnay/rust-toolchain@stable
       - name: Run 10k / 50k / 100k phase scaling suite
         run: python3 benchmarks/scalability/run.py
@@ -83,7 +83,7 @@ jobs:
     runs-on: windows-latest
     timeout-minutes: 20
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: dtolnay/rust-toolchain@stable
       - name: Locate and load MSVC tools
         shell: pwsh
@@ -151,3 +151,21 @@ jobs:
       - name: King20 direct PE gate
         shell: pwsh
         run: .\tests\test_direct_pe_king20.ps1
+
+  macos-host-link:
+    runs-on: macos-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v5
+      - uses: dtolnay/rust-toolchain@stable
+      - name: Build and test macOS toolchain
+        run: |
+          cargo test --locked
+          cargo build --release --bin lpp --bin lpp-link
+      - name: Compile runtime and run Cranelift Mach-O fallback
+        run: |
+          clang -O2 -fPIC -c lpp_runtime.c -o /tmp/lpp_runtime.o
+          cp tests/arith.lpp /tmp/arith.lpp
+          LPP_AOT=1 target/release/lpp /tmp/arith.lpp
+          clang /tmp/arith.o /tmp/lpp_runtime.o -o /tmp/arith
+          test "$(/tmp/arith)" = $'15\n5\n50\n2'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -73,8 +73,46 @@ jobs:
           name: lpp-windows-x86_64
           path: lpp-windows-x86_64.zip
 
+  macos-x86_64:
+    runs-on: macos-13
+    steps:
+      - uses: actions/checkout@v5
+      - uses: dtolnay/rust-toolchain@stable
+      - name: Build and package Intel macOS release
+        run: |
+          cargo build --release --locked --bin lpp --bin lpp-link
+          mkdir -p package/lpp-macos-x86_64/bin package/lpp-macos-x86_64/lib
+          cp target/release/lpp package/lpp-macos-x86_64/bin/
+          cp target/release/lpp-link package/lpp-macos-x86_64/bin/
+          clang -O2 -fPIC -c lpp_runtime.c -o package/lpp-macos-x86_64/lib/lpp_runtime.o
+          cp lpp_runtime.c package/lpp-macos-x86_64/lib/
+          tar -C package -czf lpp-macos-x86_64.tar.gz lpp-macos-x86_64
+      - uses: actions/upload-artifact@v4
+        with:
+          name: lpp-macos-x86_64
+          path: lpp-macos-x86_64.tar.gz
+
+  macos-arm64:
+    runs-on: macos-14
+    steps:
+      - uses: actions/checkout@v5
+      - uses: dtolnay/rust-toolchain@stable
+      - name: Build and package Apple Silicon macOS release
+        run: |
+          cargo build --release --locked --bin lpp --bin lpp-link
+          mkdir -p package/lpp-macos-arm64/bin package/lpp-macos-arm64/lib
+          cp target/release/lpp package/lpp-macos-arm64/bin/
+          cp target/release/lpp-link package/lpp-macos-arm64/bin/
+          clang -O2 -fPIC -c lpp_runtime.c -o package/lpp-macos-arm64/lib/lpp_runtime.o
+          cp lpp_runtime.c package/lpp-macos-arm64/lib/
+          tar -C package -czf lpp-macos-arm64.tar.gz lpp-macos-arm64
+      - uses: actions/upload-artifact@v4
+        with:
+          name: lpp-macos-arm64
+          path: lpp-macos-arm64.tar.gz
+
   publish:
-    needs: [linux-x86_64, windows-x86_64]
+    needs: [linux-x86_64, windows-x86_64, macos-x86_64, macos-arm64]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/download-artifact@v4
@@ -88,3 +126,5 @@ jobs:
           files: |
             artifacts/lpp-linux-x86_64/lpp-linux-x86_64.tar.gz
             artifacts/lpp-windows-x86_64/lpp-windows-x86_64.zip
+            artifacts/lpp-macos-x86_64/lpp-macos-x86_64.tar.gz
+            artifacts/lpp-macos-arm64/lpp-macos-arm64.tar.gz

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -250,7 +250,7 @@ checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
 
 [[package]]
 name = "lpp"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "cranelift-codegen",
  "cranelift-frontend",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lpp"
-version = "0.1.1"
+version = "0.1.2"
 edition = "2024"
 
 [dependencies]

--- a/Doc.md
+++ b/Doc.md
@@ -16,7 +16,8 @@ This guide breaks down the current working state of L++ and explains exactly how
 | Ownership | ARC structs, aliases, owned/borrowed returns, closures, lists | Strong cycles are rejected until `Weak`/arena/cycle-collection support exists. |
 | Direct linker | `.text`, `.rodata`, GOT imports, ARC, closures, lists, King20 20/20 | File I/O, networking, threads, JSON, `.data`/`.bss`, and dynamic imports use fallback linking. |
 | C backend | Compatibility/debug path and observable parity suite | It is not the authoritative ownership implementation. |
-| Windows | COFF + `lpp_runtime.obj` + MSVC host-link fallback | Direct PE linker work is beginning. |
+| Windows | COFF + `lpp_runtime.obj` + MSVC host-link fallback | Direct PE runtime and King20 gate are in progress. |
+| macOS | Mach-O object + clang host-link fallback | Direct Mach-O work is planned; Intel and Apple Silicon release packaging is added. |
 
 ### Ownership vocabulary
 

--- a/README.md
+++ b/README.md
@@ -234,7 +234,7 @@ LPP_FROM_SOURCE=1 ./install.sh
 # PowerShell: $env:LPP_FROM_SOURCE=1; .\install.ps1
 ```
 
-Release bundles currently target Linux x86-64 and Windows x86-64. macOS remains a source-build / future Mach-O target.
+Release bundles target Linux x86-64, Windows x86-64, macOS x86-64, and macOS arm64. macOS currently uses the verified clang host-link fallback while direct Mach-O work begins.
 
 ### Command model: files vs packages
 

--- a/documentation/MacOS_Native_Toolchain.md
+++ b/documentation/MacOS_Native_Toolchain.md
@@ -1,0 +1,76 @@
+# macOS Native Toolchain Roadmap
+
+## Current macOS support
+
+```text
+Cranelift Mach-O object emission     supported
+clang host-link fallback             validated in CI
+release bundles                      planned for Intel and Apple Silicon
+Direct Mach-O executable emitter     not implemented yet
+```
+
+## M0 — Host fallback and release packaging
+
+macOS CI validates:
+
+```text
+cargo test
+Cranelift AOT Mach-O object
+clang runtime object
+clang link
+correct executable output
+```
+
+The release workflow packages:
+
+```text
+lpp-macos-x86_64.tar.gz
+lpp-macos-arm64.tar.gz
+```
+
+Normal macOS users can install a release bundle without Rust once the matching release asset is published.
+
+## M1 — Mach-O object inspection
+
+`lpp-link inspect` already uses the shared object parser. The next direct-link step is to classify Mach-O sections, symbols, relocations, and architecture-specific object details under macOS CI.
+
+## M2 — Direct Mach-O MVP
+
+A real direct executable writer requires:
+
+```text
+Mach header 64
+LC_SEGMENT_64 commands
+__TEXT / __text
+__TEXT / __const
+__LINKEDIT
+symbol table and string table
+entry point command
+rebase/bind information
+```
+
+The first direct target is a runtime-free console executable on one architecture at a time.
+
+## M3 — Darwin runtime
+
+The Linux direct runtime uses syscalls; macOS needs Darwin-compatible runtime and loader behavior. Later work includes:
+
+```text
+libSystem imports
+write output path
+allocation API
+ARC runtime
+closure/list runtime
+King20 direct Mach-O gate
+```
+
+## Gate
+
+```text
+King20 Stable
+20 / 20
+through lpp-link Mach-O
+on macOS x86-64 and arm64
+```
+
+Until then, macOS uses the verified clang host-link fallback.

--- a/install.sh
+++ b/install.sh
@@ -5,8 +5,23 @@ PROJECT_DIR=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
 INSTALL_DIR=${LPP_INSTALL_DIR:-"$HOME/.lpp"}
 BIN_DIR="$INSTALL_DIR/bin"
 LIB_DIR="$INSTALL_DIR/lib"
-VERSION=${LPP_VERSION:-v0.1.0}
-RELEASE_URL="https://github.com/samarnever-droid/lplusplus/releases/download/$VERSION/lpp-linux-x86_64.tar.gz"
+VERSION=${LPP_VERSION:-v0.1.2}
+
+case "$(uname -s):$(uname -m)" in
+  Linux:x86_64|Linux:amd64)
+    RELEASE_TARGET="lpp-linux-x86_64"
+    ;;
+  Darwin:arm64)
+    RELEASE_TARGET="lpp-macos-arm64"
+    ;;
+  Darwin:x86_64)
+    RELEASE_TARGET="lpp-macos-x86_64"
+    ;;
+  *)
+    RELEASE_TARGET=""
+    ;;
+esac
+RELEASE_URL="https://github.com/samarnever-droid/lplusplus/releases/download/$VERSION/${RELEASE_TARGET}.tar.gz"
 
 printf '%s\n' "========================================================"
 printf '%s\n' "                 L++ GLOBAL INSTALLER                   "
@@ -15,6 +30,7 @@ printf '%s\n' "========================================================"
 mkdir -p "$BIN_DIR" "$LIB_DIR"
 
 install_release() {
+    [ -n "$RELEASE_TARGET" ] || return 1
     command -v curl >/dev/null 2>&1 || return 1
     command -v tar >/dev/null 2>&1 || return 1
     temp=$(mktemp -d "${TMPDIR:-/tmp}/lpp-release.XXXXXX")
@@ -24,7 +40,7 @@ install_release() {
         return 1
     fi
     tar -xzf "$temp/lpp.tar.gz" -C "$temp"
-    root="$temp/lpp-linux-x86_64"
+    root="$temp/$RELEASE_TARGET"
     [ -x "$root/bin/lpp" ] || return 1
     printf '%s\n' "[2/3] Installing compiler, linker, and packaged runtimes..."
     cp "$root/bin/lpp" "$BIN_DIR/lpp"
@@ -48,8 +64,10 @@ install_source() {
     cp "$PROJECT_DIR/lpp_runtime.c" "$LIB_DIR/lpp_runtime.c"
     if command -v cc >/dev/null 2>&1; then
         cc -O2 -fPIC -c "$LIB_DIR/lpp_runtime.c" -o "$LIB_DIR/lpp_runtime.o"
-        cc -O2 -ffreestanding -fno-stack-protector -fno-pic -mno-red-zone \
-            -c "$PROJECT_DIR/runtime/linux_x86_64_min.c" -o "$LIB_DIR/lpp_runtime_min.o" || true
+        if [ "$(uname -s):$(uname -m)" = "Linux:x86_64" ]; then
+            cc -O2 -ffreestanding -fno-stack-protector -fno-pic -mno-red-zone \
+                -c "$PROJECT_DIR/runtime/linux_x86_64_min.c" -o "$LIB_DIR/lpp_runtime_min.o" || true
+        fi
     fi
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -66,7 +66,7 @@ fn main() {
     
     for arg in args.iter().skip(1) {
         if arg == "--version" || arg == "-v" {
-            println!("L++ Compiler v0.1.1");
+            println!("L++ Compiler v0.1.2");
             return;
         } else if arg == "--help" || arg == "-h" {
             println!("L++ (L Plus Plus) Compiler, Codegen Backend & Package Manager");
@@ -291,7 +291,7 @@ fn main() {
                 println!("TIMING_JSON: {{\"io\": {}, \"lex\": {}, \"parse\": {}, \"semantic\": {}, \"typecheck\": {}, \"escape\": {}, \"mir\": {}, \"aot\": {}, \"total\": {}}}", 
                    io_time.as_secs_f64(), lex_time.as_secs_f64(), parse_time.as_secs_f64(), sem_time.as_secs_f64(), ty_time.as_secs_f64(), esc_time.as_secs_f64(), mir_time.as_secs_f64(), aot_time.as_secs_f64(), total_time.as_secs_f64());
             } else if !dump_ast && !dump_symbols && !dump_types && !dump_escape && !dump_mir && !dump_c {
-                println!("L++ v0.1.1\n");
+                println!("L++ v0.1.2\n");
                 if explicit_emit {
                     println!("Artifacts emitted next to the source file.");
                 } else {


### PR DESCRIPTION
## Summary

- adds macOS x86_64 and arm64 release artifacts
- updates release installer selection for Linux/macOS architectures
- adds macOS clang host-link fallback CI
- adds macOS native toolchain roadmap
- prepares v0.1.2

## Boundaries

macOS direct Mach-O output is not claimed yet. The release uses the verified clang fallback path.

## Verification

- `sh -n install.sh`
- `cargo test`
- macOS CI validates Mach-O object and clang fallback.