### PR TITLE
🔒 Fix command injection in lpp_command_exec and lpp_command_output

### DIFF
--- a/lpp_runtime.c
+++ b/lpp_runtime.c
@@ -2109,9 +2109,23 @@ int64_t lpp_vec_i64_checksum(int64_t n) {
 #endif
 }
 
+static int is_safe_command(const char *cmd) {
+    if (!cmd) return 0;
+    while (*cmd) {
+        switch (*cmd) {
+            case ';': case '|': case '&': case '<': case '>':
+            case '$': case '`': case '\n': case '\r': case '(': case ')':
+                return 0;
+        }
+        cmd++;
+    }
+    return 1;
+}
+
 int64_t lpp_command_exec(int64_t cmd_ptr) {
     if (!cmd_ptr) return -1;
     const char *cmd = (const char *)(intptr_t)cmd_ptr;
+    if (!is_safe_command(cmd)) return -1;
     int res = system(cmd);
     return (int64_t)res;
 }
@@ -2123,6 +2137,11 @@ int64_t lpp_command_output(int64_t cmd_ptr) {
         return (int64_t)(intptr_t)empty;
     }
     const char *cmd = (const char *)(intptr_t)cmd_ptr;
+    if (!is_safe_command(cmd)) {
+        char *empty = (char *)lpp_arc_alloc(1);
+        empty[0] = '\0';
+        return (int64_t)(intptr_t)empty;
+    }
     
 #if defined(_WIN32)
     FILE *fp = _popen(cmd, "r");


### PR DESCRIPTION
🎯 **What:** The vulnerability fixed is a command injection in `lpp_command_exec` and `lpp_command_output` located in `lpp_runtime.c`, which passed an unvalidated string pointer directly to `system()` and `popen()`.

⚠️ **Risk:** The potential impact if left unfixed is high as an attacker could execute arbitrary commands via shell metacharacters, potentially compromising the system.

🛡️ **Solution:** The fix addresses the vulnerability by adding a strict input validation function (`is_safe_command`) that checks for and rejects any string containing shell metacharacters before executing the command. This prevents shell injection while retaining basic command execution capabilities.

---
*PR created automatically by Jules for task [2158190340198926131](https://jules.google.com/task/2158190340198926131) started by @samarofficals*