### PR TITLE
ci: fix unresolved symbols for exit_only.exe in windows coff fallback

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -346,7 +346,7 @@ jobs:
               noop()
           "@ | Set-Content -Path "$work\exit_only.lpp" -Encoding ascii
           & target\release\lpp.exe "$work\exit_only.lpp"
-          & target\release\lpp-link.exe pe "$work\exit_only.obj" -o "$work\exit_only.exe" 2>&1
+          & target\release\lpp-link.exe pe "$work\exit_only.obj" "$work\lpp_runtime_min.obj" -o "$work\exit_only.exe" 2>&1
           & "$work\exit_only.exe"
           Write-Host "exit_only result: $LASTEXITCODE"
           # Step 4: test full version


### PR DESCRIPTION
Provides the lpp_runtime_min.obj runtime object to lpp-link when linking the exit_only.exe test file to fix unresolved symbols for lpp_* builtins.

---
*PR created automatically by Jules for task [13458189690146337576](https://jules.google.com/task/13458189690146337576) started by @samarofficals*