### PR TITLE
Rename workflow and remove Upterm session step

### DIFF
--- a/.github/workflows/mac-remote-terminal.yml
+++ b/.github/workflows/mac-remote-terminal.yml
@@ -1,4 +1,5 @@
-name: Mac Live Upterm Session
+```yaml
+name: Mac Build
 
 on:
   workflow_dispatch:
@@ -10,7 +11,7 @@ permissions:
   contents: write
 
 jobs:
-  mac-upterm:
+  mac-build:
     runs-on: macos-latest
     timeout-minutes: 360
 
@@ -22,8 +23,4 @@ jobs:
       - name: Build L++ toolchain on macOS
         run: |
           cargo build --release --bin lpp --bin lpp-link
-
-      - name: Setup Live Interactive Upterm Session
-        uses: owenthereal/action-upterm@v1
-        with:
-          limit-access-to-actor: false
+```


### PR DESCRIPTION
Updated workflow to change name and remove Upterm session setup.

## Summary

<!-- What changed and why? Keep this concise. -->

## Change type

- [ ] Compiler frontend / type system
- [ ] Ownership / ARC / MIR
- [ ] Cranelift / native linker
- [ ] C compatibility backend
- [ ] Runtime
- [ ] Windows / platform support
- [ ] Website / documentation
- [ ] Benchmark / CI

## Verification

- [ ] `cargo test`
- [ ] Relevant linker or runtime integration test
- [ ] `sh tests/run_aot_parity.sh` when behavior is shared by C/AOT
- [ ] Website build, if website files changed
- [ ] Windows CI path considered, if native-linker files changed

## Ownership checklist

<!-- Required for ARC, MIR, structs, closures, lists, aliases, and returns. -->

- [ ] No new unpaired ownership edge was introduced.
- [ ] `Borrow`, `Move`, `Retain`, `Release`, and `ReturnOwned` behavior is documented where relevant.
- [ ] Destructor behavior is documented where relevant.
- [ ] Regression coverage was added or updated.

## Benchmark / generated artifact checklist

- [ ] King20 Stable was not modified.
- [ ] Generated artifacts were not committed.
- [ ] Performance claims include environment and methodology.

## Documentation

- [ ] README updated if user-facing behavior changed.
- [ ] Doc.md or roadmap updated if capability boundaries changed.

## Notes for reviewers

<!-- Explicitly list unsupported cases, tradeoffs, or follow-up work. -->
