### PR TITLE
🧹 [Code Health] Use str_lower for registry query

### DIFF
--- a/pm/src/registry.lpp
+++ b/pm/src/registry.lpp
@@ -219,7 +219,7 @@ def search_registry(query: Str) -> Void:
         print_str("\033[1;31m[lpp-pm] ERROR:\033[0m Failed to fetch registry.")
         return
 
-    mut lower_query := query   # TODO: use str_to_lower when available
+    mut lower_query := str_lower(query)
     mut found := 0
 
     h_json := json_parse(json_text)
@@ -261,9 +261,9 @@ def search_registry(query: Str) -> Void:
                 q2   := str_find(rest, "\"")
                 if q2 >= 0:
                     cur_pkg = str_substr(rest, 0, q2)
-                    mut matched := str_len(query) == 0
+                    mut matched := str_len(lower_query) == 0
                     if !matched:
-                        matched = str_find(cur_pkg, query) >= 0
+                        matched = str_find(str_lower(cur_pkg), lower_query) >= 0
                     if matched:
                         print_str(str_concat("  \033[32m", str_concat(cur_pkg, "\033[0m")))
                         print_str(str_concat("      lpp add ", cur_pkg))


### PR DESCRIPTION
🎯 **What:** The code health issue addressed
The TODO comment in `pm/src/registry.lpp` requesting to use `str_to_lower` for registry queries was implemented. The code was updated to use the runtime built-in function `str_lower`.

💡 **Why:** How this improves maintainability
This implements proper case-insensitive searching in the registry, which is a required functionality and removes an unaddressed TODO from the codebase. It improves user experience by allowing registry searches independent of case, using proper string utility functions.

✅ **Verification:** How you confirmed the change is safe
Ran `cargo test` and `sh tests/run_aot_parity.sh` to ensure no functionality is broken and compilation succeeds. Verified that the package manager could run locally without crashing. Code review passed successfully.

✨ **Result:** The improvement achieved
The registry search now handles lowercase strings via `str_lower(query)` and ensures `cur_pkg` is also converted properly for substring matching. Code readability is improved and the functionality works as expected.

---
*PR created automatically by Jules for task [4834527139001791768](https://jules.google.com/task/4834527139001791768) started by @samarofficals*