### PR TITLE
Fix FFI, runtime linkage bugs, and enhance CLI tests

### DIFF
--- a/bug_hunt.sh
+++ b/bug_hunt.sh
@@ -1,9 +1,29 @@
 #!/bin/bash
 LPP="./target/debug/lpp"
-echo -e "\n[1/5] Testing lpp-engine..."
-$LPP packages/lpp-engine/src/main.lpp --linker direct
-if [ $? -eq 0 ]; then
-    ./packages/lpp-engine/src/main
-else
-    echo "lpp-engine compilation failed!"
-fi
+
+for i in {1..5}; do
+    pkg=""
+    case $i in
+        1) pkg="lpp-engine" ;;
+        2) pkg="lpp-math" ;;
+        3) pkg="lpp-git" ;;
+        4) pkg="lpp-zip" ;;
+        5) pkg="lpp-bindgen" ;;
+    esac
+
+    echo -e "\n[$i/5] Testing $pkg..."
+    if [ -f "packages/$pkg/src/main.lpp" ]; then
+        $LPP packages/$pkg/src/main.lpp --linker direct
+        if [ $? -eq 0 ]; then
+            if ! ./packages/$pkg/src/main; then
+                echo "Failed natively. Trying Emulator (WASM)..."
+                $LPP packages/$pkg/src/main.lpp --target wasm32-wasi
+                wasmtime packages/$pkg/src/main.wasm || echo "Emulator failed too."
+            fi
+        else
+            echo "$pkg compilation failed!"
+        fi
+    else
+        echo "No main.lpp found for $pkg."
+    fi
+done

--- a/runtime/linux_x86_64_min.c
+++ b/runtime/linux_x86_64_min.c
@@ -2228,3 +2228,5 @@ int64_t lpp_vec_i64_checksum(int64_t n) {
 /* ── Native 2D GUI & Windowing ── */
 #include "lpp_gui.c"
 
+
+void *lpp_str_split(const char *s,int64_t d) { void*l=lpp_list_new_arc();if(!l)return 0;if(!s||!*s)return l; char ch=(char)d;const char*st=s; for(;;){if(*s==ch||*s==0){int64_t ln=(int64_t)(s-st);char*pc=(char*)lpp_arc_alloc(ln+1);if(pc){memcpy(pc,st,(int)ln);pc[ln]=0;lpp_list_push_arc(l,pc);lpp_arc_release(pc);}if(*s==0)break;st=s+1;}s++;} return l; }

--- a/src/bin/lpp-bench.rs
+++ b/src/bin/lpp-bench.rs
@@ -10,6 +10,7 @@
 //!   lpp-bench [--linkers direct,mold,c] [--suite king20] [--json] [--disk] [--mem]
 //!   lpp-bench --self-test          (run 15 built-in integration tests)
 
+use std::io::Read;
 use std::env;
 use std::fs;
 use std::path::{Path, PathBuf};

--- a/src/pm.rs
+++ b/src/pm.rs
@@ -2726,7 +2726,8 @@ fn fetch_registry_json() -> Option<String> {
     let max_retries = 3;
 
     // ── Primary: LPP_REGISTRY_URL (or official .bond registry) ────────────────
-    for _attempt in 1..=max_retries {
+    #[allow(unused_variables)]
+    for attempt in 1..=max_retries {
         let curl_cmd = if cfg!(windows) { "curl.exe" } else { "curl" };
         let output = std::process::Command::new(curl_cmd)
             .args(["-fsSL", "--max-time", "8", &primary_url])

--- a/src/pm.rs
+++ b/src/pm.rs
@@ -2726,7 +2726,7 @@ fn fetch_registry_json() -> Option<String> {
     let max_retries = 3;
 
     // ── Primary: LPP_REGISTRY_URL (or official .bond registry) ────────────────
-    for attempt in 1..=max_retries {
+    for _attempt in 1..=max_retries {
         let curl_cmd = if cfg!(windows) { "curl.exe" } else { "curl" };
         let output = std::process::Command::new(curl_cmd)
             .args(["-fsSL", "--max-time", "8", &primary_url])

--- a/tests/test_ffi.lpp
+++ b/tests/test_ffi.lpp
@@ -2,15 +2,15 @@
 
 extern "C":
     def abs(x: Int) -> Int
-    def _getpid() -> Int
+    def getpid() -> Int
 
 def main():
     # Call C stdlib abs()
     n := abs(-42)
     print(n)
 
-    # Call _getpid()
-    pid := _getpid()
+    # Call getpid()
+    pid := getpid()
     print(pid)
 
     print("ffi works!")


### PR DESCRIPTION
This PR addresses several bugs and enhances the CLI testing script as requested:
1. **FFI Bug**: Fixed `tests/test_ffi.lpp` by using the standard POSIX `getpid` instead of `_getpid`, resolving linkage errors on Linux.
2. **Benchmark Compilation**: Added missing `Read` trait import in `src/bin/lpp-bench.rs` resolving rust compilation issues.
3. **C Runtime Segfault & Unresolved Symbols**: Added `lpp_str_split` definition to `runtime/linux_x86_64_min.c` (using `memcpy` since `lpp_memcpy` isn't available), which fixed native compilation and execution of `lpp-bindgen` and similar packages.
4. **CLI Tests**: Rewrote `bug_hunt.sh` to properly execute 5 test iterations on L++ packages, adding a WASM emulator fallback (`wasm32-wasi` via `wasmtime`) when native execution fails.

---
*PR created automatically by Jules for task [4480955401424548403](https://jules.google.com/task/4480955401424548403) started by @samarofficals*