### PR TITLE
Fix linking and FFI issues to ensure all tests pass

### DIFF
--- a/src/pm.rs
+++ b/src/pm.rs
@@ -1776,6 +1776,8 @@ pub fn host_link_binary_target(
                 Some(obj) => cmd.arg(obj),
                 None => cmd.arg(&runtime_src_path),
             };
+        } else if let Some(runtime_obj) = resolve_min_runtime_object() {
+            cmd.arg(runtime_obj);
         }
         cmd.arg("-lm"); // runtime math references must precede the library
         if is_android {

--- a/tests/test_ffi.lpp
+++ b/tests/test_ffi.lpp
@@ -2,7 +2,7 @@
 
 extern "C":
     def abs(x: Int) -> Int
-    def _getpid() -> Int
+    def getpid() -> Int
 
 def main():
     # Call C stdlib abs()
@@ -10,7 +10,7 @@ def main():
     print(n)
 
     # Call _getpid()
-    pid := _getpid()
+    pid := getpid()
     print(pid)
 
     print("ffi works!")

--- a/tests/test_packaged_runtime.sh
+++ b/tests/test_packaged_runtime.sh
@@ -23,7 +23,7 @@ fi
 mkdir -p "$TEMP/install/bin" "$TEMP/install/lib" "$TEMP/work"
 cp "$COMPILER" "$TEMP/install/bin/lpp"
 cp "$LINKER" "$TEMP/install/bin/lpp-link"
-"$CC" -Os -ffreestanding -fno-stack-protector -fno-pic -mno-red-zone \
+"$CC" -Os -ffreestanding -fno-stack-protector -fPIC -mno-red-zone \
     -fno-reorder-blocks-and-partition \
     -c "$ROOT/runtime/linux_x86_64_min.c" -o "$TEMP/install/lib/lpp_runtime_min.o"
 


### PR DESCRIPTION
This PR fixes several bugs that caused local test suites to fail.

1. **FFI Bug**: Changed `_getpid` to `getpid` in `tests/test_ffi.lpp`. `_getpid` is a Windows/MSVC specific name, while on Linux/Unix standard POSIX platforms it is `getpid`. The test failed due to an undefined reference on Linux.
2. **Packaged Runtime Linker Bug**: Fixed an issue in `src/pm.rs` where the package manager failed to fall back to the prebuilt `lpp_runtime_min.o` object when `lpp_runtime.c` source was not available, causing linkage failures in packaged environments.
3. **Packaged Runtime Test Script Bug**: Fixed `tests/test_packaged_runtime.sh` to compile the min runtime object using `-fPIC` instead of `-fno-pic`. Modern Linux builds default to PIE (Position Independent Executable), and linking a non-PIC object was causing relocation errors (`R_X86_64_32S`).

All CLI tests run successfully now via `LPP_EMULATOR=1 sh tests/test_*.sh`.

---
*PR created automatically by Jules for task [7297506943959826043](https://jules.google.com/task/7297506943959826043) started by @samarofficals*