### PR TITLE
Fix CLI source commands to properly distinguish between files and directories

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -563,13 +563,13 @@ fn real_main() -> i32 {
     let mut source_check_command = false;
     let mut is_emit_cmd = false;
     let mut source_run_command = false;
-    if args.len() > 2 && args[1] == "emit" {
+    if args.len() > 2 && args[1] == "emit" && (args[2].ends_with(".lpp") || Path::new(&args[2]).is_file()) {
         is_emit_cmd = true;
         args.remove(1);
-    } else if args.len() > 2 && args[1] == "check" && args[2].ends_with(".lpp") {
+    } else if args.len() > 2 && args[1] == "check" && (args[2].ends_with(".lpp") || Path::new(&args[2]).is_file()) {
         source_check_command = true;
         args.remove(1);
-    } else if args.len() > 2 && args[1] == "run" && (args[2].ends_with(".lpp") || Path::new(&args[2]).exists()) {
+    } else if args.len() > 2 && args[1] == "run" && (args[2].ends_with(".lpp") || Path::new(&args[2]).is_file()) {
         source_run_command = true;
         args.remove(1);
     }

--- a/tests/test_source_commands.sh
+++ b/tests/test_source_commands.sh
@@ -29,3 +29,43 @@ EOF
 "$LPP" emit "$TEMP/example.lpp" --aot >/dev/null
 [ -e "$TEMP/example.o" ]
 echo "PASS source command split"
+
+# Test that directories are routed to the package manager, not treated as source files.
+PKG_DIR="$TEMP/dummy_pkg"
+mkdir -p "$PKG_DIR/src"
+cat > "$PKG_DIR/lpp.toml" <<'INNER'
+[package]
+name = "dummy_pkg"
+version = "0.1.0"
+INNER
+cat > "$PKG_DIR/src/main.lpp" <<'INNER'
+def main():
+    print(1)
+INNER
+
+# We capture output to verify package manager actions (which usually print "Building project")
+OUT_RUN=$(cd "$PKG_DIR" && "$LPP" run 2>&1 || true)
+if ! echo "$OUT_RUN" | grep -q "Building"; then
+    echo "FAIL: lpp run on package directory did not route to package manager"
+    exit 1
+fi
+
+OUT_CHECK=$(cd "$PKG_DIR" && "$LPP" check 2>&1 || true)
+if ! echo "$OUT_CHECK" | grep -q "Checking"; then
+    echo "FAIL: lpp check on package directory did not route to package manager"; echo "$OUT_CHECK"
+    exit 1
+fi
+
+# Create a source file without .lpp extension
+FILE_NO_EXT="$TEMP/source_no_ext"
+cat > "$FILE_NO_EXT" <<'INNER'
+def main():
+    print(42)
+INNER
+
+"$LPP" run "$FILE_NO_EXT" >/dev/null
+"$LPP" check "$FILE_NO_EXT" >/dev/null
+"$LPP" emit "$FILE_NO_EXT" >/dev/null
+[ -e "$TEMP/source_no_ext.o" ]
+
+echo "PASS directory vs file split"


### PR DESCRIPTION
Fix CLI source commands to properly distinguish between files and directories

The lpp CLI previously incorrectly intercepted package commands like `lpp run my_package` if `my_package` was a directory, because it used `.exists()` instead of `.is_file()` to check if the target was a source file. This commit updates the CLI arguments parsing logic for `run`, `check`, and `emit` to strictly use `.is_file()`. Also added 5 CLI test assertions to `test_source_commands.sh` to prevent regressions.

---
*PR created automatically by Jules for task [10513657095613123858](https://jules.google.com/task/10513657095613123858) started by @samarofficals*