### PR TITLE
fix: resolve ambiguous CLI command bug for .lpp package directories

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -563,13 +563,13 @@ fn real_main() -> i32 {
     let mut source_check_command = false;
     let mut is_emit_cmd = false;
     let mut source_run_command = false;
-    if args.len() > 2 && args[1] == "emit" {
+    if args.len() > 2 && args[1] == "emit" && (args[2].ends_with(".lpp") && !Path::new(&args[2]).is_dir() || Path::new(&args[2]).is_file()) {
         is_emit_cmd = true;
         args.remove(1);
-    } else if args.len() > 2 && args[1] == "check" && args[2].ends_with(".lpp") {
+    } else if args.len() > 2 && args[1] == "check" && (args[2].ends_with(".lpp") && !Path::new(&args[2]).is_dir() || Path::new(&args[2]).is_file()) {
         source_check_command = true;
         args.remove(1);
-    } else if args.len() > 2 && args[1] == "run" && (args[2].ends_with(".lpp") || Path::new(&args[2]).exists()) {
+    } else if args.len() > 2 && args[1] == "run" && (args[2].ends_with(".lpp") && !Path::new(&args[2]).is_dir() || Path::new(&args[2]).is_file()) {
         source_run_command = true;
         args.remove(1);
     }
@@ -645,9 +645,10 @@ fn real_main() -> i32 {
             || first_arg == "add"
             || first_arg == "remove"
             || first_arg == "update"
-            || first_arg == "check"
+            || (first_arg == "check" && !source_check_command)
             || first_arg == "build"
-            || first_arg == "run"
+            || (first_arg == "run" && !source_run_command)
+            || (first_arg == "emit" && !is_emit_cmd)
             || first_arg == "test"
             || first_arg == "new"
             || first_arg == "search"
@@ -878,7 +879,7 @@ fn real_main() -> i32 {
             walk(Path::new("."), &mut all_files, true);
         } else {
             for target_path in &check_paths {
-                if target_path.is_file() {
+                if target_path.is_file() || (target_path.exists() && !target_path.is_dir() && target_path.extension().map_or(false, |e| e == "lpp")) {
                     if target_path.extension().map_or(false, |e| e == "lpp") {
                         all_files.push(target_path.clone());
                     }

--- a/tests/test_source_commands.sh
+++ b/tests/test_source_commands.sh
@@ -29,3 +29,61 @@ EOF
 "$LPP" emit "$TEMP/example.lpp" --aot >/dev/null
 [ -e "$TEMP/example.o" ]
 echo "PASS source command split"
+
+mkdir -p "$TEMP/project"
+cat > "$TEMP/project/lpp.toml" <<'INNEREOF'
+[package]
+name = "test_pkg"
+version = "0.1.0"
+entry = "src/main.lpp"
+INNEREOF
+
+mkdir -p "$TEMP/project/src"
+cat > "$TEMP/project/src/main.lpp" <<'INNEREOF'
+def main():
+    print(42)
+INNEREOF
+
+(cd "$TEMP/project" && "$LPP" run >/dev/null)
+[ -e "$TEMP/project/LppData/build/release/output" ] || [ -e "$TEMP/project/LppData/build/release/test_pkg" ] || [ -e "$TEMP/project/LppData/build/release/output.exe" ] || [ -e "$TEMP/project/LppData/build/release/test_pkg.exe" ]
+echo "PASS package run command"
+
+mkdir -p "$TEMP/project2"
+cat > "$TEMP/project2/lpp.toml" <<'INNEREOF'
+[package]
+name = "test_pkg2"
+version = "0.1.0"
+entry = "src/main.lpp"
+INNEREOF
+
+mkdir -p "$TEMP/project2/src"
+cat > "$TEMP/project2/src/main.lpp" <<'INNEREOF'
+def main():
+    print(42)
+INNEREOF
+
+(cd "$TEMP/project2" && "$LPP" check >/dev/null)
+echo "PASS package check command"
+
+mkdir -p "$TEMP/test.lpp"
+cat > "$TEMP/test.lpp/lpp.toml" <<'INNEREOF'
+[package]
+name = "test_pkg_dot_lpp"
+version = "0.1.0"
+entry = "src/main.lpp"
+INNEREOF
+
+mkdir -p "$TEMP/test.lpp/src"
+cat > "$TEMP/test.lpp/src/main.lpp" <<'INNEREOF'
+def main():
+    print(123)
+INNEREOF
+
+(cd "$TEMP/test.lpp" && "$LPP" run >/dev/null)
+echo "PASS package run with .lpp folder name"
+
+(cd "$TEMP/test.lpp" && "$LPP" check >/dev/null)
+echo "PASS package check with .lpp folder name"
+
+(cd "$TEMP/test.lpp" && "$LPP" build >/dev/null)
+echo "PASS package build with .lpp folder name"


### PR DESCRIPTION
Fixed a bug in the CLI where the compiler would misinterpret package directories named with an `.lpp` extension as single source files. Added tests to verify the source command vs package command resolution logic correctly differentiates them based on file types.

---
*PR created automatically by Jules for task [9161264138973112615](https://jules.google.com/task/9161264138973112615) started by @samarofficals*