### PR TITLE
Fix CLI routing for package directories

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -563,13 +563,19 @@ fn real_main() -> i32 {
     let mut source_check_command = false;
     let mut is_emit_cmd = false;
     let mut source_run_command = false;
+
+    // Check if the argument is likely a single file command rather than a PM workspace directory
+    let is_source_file = |path: &str| {
+        path.ends_with(".lpp") || Path::new(path).is_file()
+    };
+
     if args.len() > 2 && args[1] == "emit" {
         is_emit_cmd = true;
         args.remove(1);
-    } else if args.len() > 2 && args[1] == "check" && args[2].ends_with(".lpp") {
+    } else if args.len() > 2 && args[1] == "check" && is_source_file(&args[2]) {
         source_check_command = true;
         args.remove(1);
-    } else if args.len() > 2 && args[1] == "run" && (args[2].ends_with(".lpp") || Path::new(&args[2]).exists()) {
+    } else if args.len() > 2 && args[1] == "run" && is_source_file(&args[2]) {
         source_run_command = true;
         args.remove(1);
     }

--- a/tests/test_source_commands.sh
+++ b/tests/test_source_commands.sh
@@ -28,4 +28,57 @@ EOF
 
 "$LPP" emit "$TEMP/example.lpp" --aot >/dev/null
 [ -e "$TEMP/example.o" ]
+
+# Setup a mock package directory
+mkdir -p "$TEMP/my_pkg/src"
+cat > "$TEMP/my_pkg/lpp.toml" <<'TOML'
+[package]
+name = "my_pkg"
+version = "0.1.0"
+TOML
+cat > "$TEMP/my_pkg/src/main.lpp" <<'LPP'
+def main():
+    print("hello from pkg")
+LPP
+
+# 1. Test lpp run <pkg_dir> routes to package manager
+output=$("$LPP" run "$TEMP/my_pkg" 2>&1 || true)
+if echo "$output" | grep -q "Is a directory"; then
+    echo "FAIL: lpp run treated package directory as a source file"
+    exit 1
+fi
+echo "PASS lpp run <pkg_dir> correctly routes to PM"
+
+# 2. Test lpp check <pkg_dir> routes to package manager
+output=$("$LPP" check "$TEMP/my_pkg" 2>&1 || true)
+if echo "$output" | grep -q "Is a directory"; then
+    echo "FAIL: lpp check treated package directory as a source file"
+    exit 1
+fi
+echo "PASS lpp check <pkg_dir> correctly routes to PM"
+
+# 3. Test lpp emit <pkg_dir> fails appropriately because it requires a single file
+output=$("$LPP" emit "$TEMP/my_pkg" 2>&1 || true)
+if ! echo "$output" | grep -q "Is a directory"; then
+    echo "FAIL: lpp emit should reject package directories. Output: $output"
+    exit 1
+fi
+echo "PASS lpp emit <pkg_dir> correctly rejected"
+
+# 4. Test lpp check <missing_file.lpp> routes to source checker and fails
+output=$("$LPP" check "$TEMP/missing.lpp" 2>&1 || true)
+if ! echo "$output" | grep -q "No such file or directory"; then
+    echo "FAIL: lpp check missing.lpp should error properly. Output: $output"
+    exit 1
+fi
+echo "PASS lpp check <missing.lpp>"
+
+# 5. Test lpp emit <missing.lpp>
+output=$("$LPP" emit "$TEMP/missing.lpp" 2>&1 || true)
+if ! echo "$output" | grep -q "Failed to read"; then
+    echo "FAIL: lpp emit missing.lpp should error on read. Output: $output"
+    exit 1
+fi
+echo "PASS lpp emit <missing.lpp>"
+
 echo "PASS source command split"


### PR DESCRIPTION
Fix CLI routing bug where `lpp run` and `lpp check` on a package directory threw "Is a directory" error instead of routing to the package manager correctly. Added 5 corresponding CLI tests.

---
*PR created automatically by Jules for task [2473688458797089769](https://jules.google.com/task/2473688458797089769) started by @samarofficals*