### PR TITLE
Fix CLI source command parsing bug and add tests

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -563,13 +563,18 @@ fn real_main() -> i32 {
     let mut source_check_command = false;
     let mut is_emit_cmd = false;
     let mut source_run_command = false;
-    if args.len() > 2 && args[1] == "emit" {
+
+    let is_source_file = |arg: &str| -> bool {
+        arg.ends_with(".lpp") || Path::new(arg).is_file()
+    };
+
+    if args.len() > 2 && args[1] == "emit" && is_source_file(&args[2]) {
         is_emit_cmd = true;
         args.remove(1);
-    } else if args.len() > 2 && args[1] == "check" && args[2].ends_with(".lpp") {
+    } else if args.len() > 2 && args[1] == "check" && is_source_file(&args[2]) {
         source_check_command = true;
         args.remove(1);
-    } else if args.len() > 2 && args[1] == "run" && (args[2].ends_with(".lpp") || Path::new(&args[2]).exists()) {
+    } else if args.len() > 2 && args[1] == "run" && is_source_file(&args[2]) {
         source_run_command = true;
         args.remove(1);
     }

--- a/tests/test_source_commands.sh
+++ b/tests/test_source_commands.sh
@@ -20,6 +20,10 @@ def main():
     print(7)
 EOF
 
+(cd "$TEMP" && "$LPP" new my_pkg) >/dev/null
+! "$LPP" check "$TEMP/my_pkg" >/dev/null 2>&1
+! "$LPP" run "$TEMP/my_pkg" >/dev/null 2>&1
+
 "$LPP" check "$TEMP/example.lpp" >/dev/null
 [ ! -e "$TEMP/example.o" ]
 


### PR DESCRIPTION
The L++ compiler CLI (`src/main.rs`) incorrectly evaluated package directories as source files for the `check`, `run`, and `emit` commands due to checking if the argument `.exists()` rather than `.is_file()`. This patch updates the condition to ensure only valid `.lpp` files or existing files trigger the source command logic. It also adds coverage for this specific CLI split logic in `tests/test_source_commands.sh`.

---
*PR created automatically by Jules for task [10099777709432729011](https://jules.google.com/task/10099777709432729011) started by @samarofficals*