### PR TITLE
fix: Fix CLI routing for source files and package directories

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -563,13 +563,13 @@ fn real_main() -> i32 {
     let mut source_check_command = false;
     let mut is_emit_cmd = false;
     let mut source_run_command = false;
-    if args.len() > 2 && args[1] == "emit" {
+    if args.len() > 2 && args[1] == "emit" && (args[2].ends_with(".lpp") || Path::new(&args[2]).is_file()) {
         is_emit_cmd = true;
         args.remove(1);
-    } else if args.len() > 2 && args[1] == "check" && args[2].ends_with(".lpp") {
+    } else if args.len() > 2 && args[1] == "check" && (args[2].ends_with(".lpp") || Path::new(&args[2]).is_file()) {
         source_check_command = true;
         args.remove(1);
-    } else if args.len() > 2 && args[1] == "run" && (args[2].ends_with(".lpp") || Path::new(&args[2]).exists()) {
+    } else if args.len() > 2 && args[1] == "run" && (args[2].ends_with(".lpp") || Path::new(&args[2]).is_file()) {
         source_run_command = true;
         args.remove(1);
     }

--- a/tests/cli_tests/test_cli_commands.sh
+++ b/tests/cli_tests/test_cli_commands.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env sh
+set -eu
+
+ROOT=$(CDPATH= cd -- "$(dirname -- "$0")/../.." && pwd)
+LPP="$ROOT/target/release/lpp"
+TEMP=$(mktemp -d "${TMPDIR:-/tmp}/lpp-cli-commands.XXXXXX")
+cleanup() { rm -rf "$TEMP"; }
+trap cleanup EXIT HUP INT TERM
+
+if [ ! -x "$LPP" ]; then
+    (cd "$ROOT" && cargo build --release --bin lpp)
+fi
+
+FAIL=0
+
+# 1. Package dir 'run'
+mkdir "$TEMP/myapp"
+cat > "$TEMP/myapp/lpp.toml" <<'TOML'
+[package]
+name = "myapp"
+version = "0.1.0"
+TOML
+mkdir "$TEMP/myapp/src"
+cat > "$TEMP/myapp/src/main.lpp" <<'LPP'
+def main():
+    print(42)
+LPP
+
+OUTPUT=$("$LPP" run "$TEMP/myapp" 2>&1 || true)
+if echo "$OUTPUT" | grep -q "Is a directory"; then
+    echo "FAIL: 'run <dir>' did not route to package manager."
+    FAIL=1
+fi
+
+# 2. Package dir 'check'
+OUTPUT=$("$LPP" check "$TEMP/myapp" 2>&1 || true)
+if echo "$OUTPUT" | grep -q "Is a directory"; then
+    echo "FAIL: 'check <dir>' did not route to package manager."
+    FAIL=1
+fi
+
+# 3. Source file 'run'
+cat > "$TEMP/mysource.lpp" <<'LPP'
+def main():
+    print(100)
+LPP
+OUTPUT=$("$LPP" run "$TEMP/mysource.lpp" 2>&1 || true)
+if ! echo "$OUTPUT" | grep -q "100"; then
+    echo "FAIL: 'run <file>' did not execute source file. Output: $OUTPUT"
+    FAIL=1
+fi
+
+# 4. Source file 'check'
+OUTPUT=$("$LPP" check "$TEMP/mysource.lpp" 2>&1 || true)
+if ! echo "$OUTPUT" | grep -q "L++ check: OK"; then
+    echo "FAIL: 'check <file>' did not execute source file check. Output: $OUTPUT"
+    FAIL=1
+fi
+
+# 5. Source file 'emit'
+OUTPUT=$("$LPP" emit "$TEMP/mysource.lpp" 2>&1 || true)
+if [ ! -e "$TEMP/mysource.o" ]; then
+    echo "FAIL: 'emit <file>' did not produce output."
+    FAIL=1
+fi
+
+if [ "$FAIL" -eq 1 ]; then
+    echo "SOME TESTS FAILED"
+    exit 1
+else
+    echo "PASS cli tests"
+fi


### PR DESCRIPTION
Fixes a bug where commands like `lpp run <dir>` incorrectly tried to execute the directory as a single source file. This also includes a shell test script containing 5 tests verifying correct behavior for both single files and package directories.

---
*PR created automatically by Jules for task [6668324093620040514](https://jules.google.com/task/6668324093620040514) started by @samarofficals*