### PR TITLE
Fix CLI source vs package parsing bugs and add tests

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -569,7 +569,7 @@ fn real_main() -> i32 {
     } else if args.len() > 2 && args[1] == "check" && args[2].ends_with(".lpp") {
         source_check_command = true;
         args.remove(1);
-    } else if args.len() > 2 && args[1] == "run" && (args[2].ends_with(".lpp") || Path::new(&args[2]).exists()) {
+    } else if args.len() > 2 && args[1] == "run" && (args[2].ends_with(".lpp") || Path::new(&args[2]).is_file()) {
         source_run_command = true;
         args.remove(1);
     }

--- a/tests/cli_tests/test_cli_commands.sh
+++ b/tests/cli_tests/test_cli_commands.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env sh
+set -eu
+
+ROOT=$(CDPATH= cd -- "$(dirname -- "$0")/../.." && pwd)
+LPP="$ROOT/target/debug/lpp"
+TEMP=$(mktemp -d "${TMPDIR:-/tmp}/lpp-cli-commands.XXXXXX")
+cleanup() { rm -rf "$TEMP"; }
+trap cleanup EXIT HUP INT TERM
+
+if [ ! -x "$LPP" ]; then
+    (cd "$ROOT" && cargo build --bin lpp)
+fi
+
+mkdir "$TEMP/pkg"
+cat > "$TEMP/pkg/lpp.toml" <<'TOML'
+[package]
+name = "pkg"
+version = "0.1.0"
+entry = "src/main.lpp"
+TOML
+mkdir "$TEMP/pkg/src"
+cat > "$TEMP/pkg/src/main.lpp" <<'LPP'
+def main():
+    print(1)
+LPP
+
+cat > "$TEMP/example.lpp" <<'LPP'
+def main():
+    print(2)
+LPP
+
+# Test 1: check source
+"$LPP" check "$TEMP/example.lpp" >/dev/null
+
+# Test 2: run source
+LPP_EMULATOR=1 "$LPP" run "$TEMP/example.lpp" >/dev/null
+
+# Test 3: emit source
+"$LPP" emit "$TEMP/example.lpp" >/dev/null
+
+# Test 4: run package
+(
+  cd "$TEMP/pkg"
+  LPP_EMULATOR=1 "$LPP" run >/dev/null
+)
+
+# Test 5: check package
+(
+  cd "$TEMP/pkg"
+  LPP_EMULATOR=1 "$LPP" check >/dev/null
+)
+
+echo "PASS 5 CLI tests"


### PR DESCRIPTION
Fixed the command line parsing to differentiate between running a single source file vs running a whole package correctly, resolving bugs where valid package directories were mistakenly treated as single files. Added CLI tests as well.

---
*PR created automatically by Jules for task [8775742327142286666](https://jules.google.com/task/8775742327142286666) started by @samarofficals*