### PR TITLE
Fix PM directory targeting bug and add tests

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -569,7 +569,7 @@ fn real_main() -> i32 {
     } else if args.len() > 2 && args[1] == "check" && args[2].ends_with(".lpp") {
         source_check_command = true;
         args.remove(1);
-    } else if args.len() > 2 && args[1] == "run" && (args[2].ends_with(".lpp") || Path::new(&args[2]).exists()) {
+    } else if args.len() > 2 && args[1] == "run" && (args[2].ends_with(".lpp") || Path::new(&args[2]).is_file()) {
         source_run_command = true;
         args.remove(1);
     }
@@ -633,6 +633,21 @@ fn real_main() -> i32 {
     }
 
     if args.len() > 1 {
+        // Handle target directory positional arguments for PM commands.
+        // If a valid PM command that operates on a project is given a directory path,
+        // navigate to it and remove the argument so the PM operates locally.
+        if (args[1] == "run" || args[1] == "build" || args[1] == "check" || args[1] == "test")
+            && args.len() > 2
+            && !args[2].starts_with('-')
+            && Path::new(&args[2]).is_dir()
+        {
+            if let Err(e) = env::set_current_dir(&args[2]) {
+                eprintln!("[L++] Failed to navigate to target directory '{}': {e}", args[2]);
+                return 1;
+            }
+            args.remove(2);
+        }
+
         let first_arg = &args[1];
         if env::var_os("LPP_PM_CHILD").is_some() {
             return pm::run_command(&args[1..]);

--- a/tests/cli_tests/test_cli_commands.sh
+++ b/tests/cli_tests/test_cli_commands.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+set -eu
+
+ROOT=$(CDPATH= cd -- "$(dirname -- "$0")/../.." && pwd)
+LPP="$ROOT/target/release/lpp"
+TEMP=$(mktemp -d "${TMPDIR:-/tmp}/lpp-cli-commands.XXXXXX")
+cleanup() { rm -rf "$TEMP"; }
+trap cleanup EXIT HUP INT TERM
+
+if ! command -v cargo >/dev/null 2>&1; then
+    echo "SKIP: requires cargo"
+    exit 0
+fi
+if [ ! -x "$LPP" ]; then
+    (cd "$ROOT" && cargo build --release --bin lpp)
+fi
+
+# Ensure package directory parsing doesn't swallow file arguments
+mkdir -p "$TEMP/mypkg/src"
+cat > "$TEMP/mypkg/lpp.toml" <<'MANIFEST'
+[package]
+name = "mypkg"
+version = "0.1.0"
+MANIFEST
+cat > "$TEMP/mypkg/src/main.lpp" <<'SRC'
+def main():
+    print(8)
+SRC
+
+# Verify package is recognized
+"$LPP" run "$TEMP/mypkg" >/dev/null
+echo "PASS PM run"
+
+# Verify file doesn't trigger package logic
+cat > "$TEMP/single.lpp" <<'SRC'
+def main():
+    print(9)
+SRC
+
+"$LPP" run "$TEMP/single.lpp" >/dev/null
+echo "PASS source run"
+
+# Verify build command on package
+"$LPP" build "$TEMP/mypkg" >/dev/null
+echo "PASS PM build"
+
+# Verify check command on package
+"$LPP" check "$TEMP/mypkg" >/dev/null
+echo "PASS PM check"
+
+# Verify check command on source
+"$LPP" check "$TEMP/single.lpp" >/dev/null
+echo "PASS source check"


### PR DESCRIPTION
Fixes a bug where package manager commands (`run`, `build`, `check`, `test`) invoked with a positional target directory (e.g. `lpp run my_package`) would not change into the directory before executing. Also adds exactly 5 integration tests to verify correct CLI behavior for both package logic and single-source files.

---
*PR created automatically by Jules for task [17987567388651878289](https://jules.google.com/task/17987567388651878289) started by @samarofficals*