### PR TITLE
Fix CLI and PM routing for package directory arguments

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -569,7 +569,7 @@ fn real_main() -> i32 {
     } else if args.len() > 2 && args[1] == "check" && args[2].ends_with(".lpp") {
         source_check_command = true;
         args.remove(1);
-    } else if args.len() > 2 && args[1] == "run" && (args[2].ends_with(".lpp") || Path::new(&args[2]).exists()) {
+    } else if args.len() > 2 && args[1] == "run" && (args[2].ends_with(".lpp") || Path::new(&args[2]).is_file()) {
         source_run_command = true;
         args.remove(1);
     }

--- a/src/pm.rs
+++ b/src/pm.rs
@@ -1968,6 +1968,20 @@ fn link_native_binary(obj_file: &Path, output_path: &Path) -> Result<(), String>
     host_link_binary(obj_file, output_path, &[])
 }
 
+fn navigate_to_target_dir(args: &[String]) {
+    for arg in args {
+        if !arg.starts_with('-') {
+            let p = std::path::Path::new(arg);
+            if p.is_dir() {
+                if let Err(e) = std::env::set_current_dir(p) {
+                    eprintln!("[L++] warning: failed to enter directory '{}': {e}", p.display());
+                }
+                break;
+            }
+        }
+    }
+}
+
 pub fn run_command(args: &[String]) -> i32 {
     if args.is_empty() {
         print_help();
@@ -2009,18 +2023,29 @@ pub fn run_command(args: &[String]) -> i32 {
         "outdated" => cmd_outdated(),
         "version" => cmd_version(&args[1..]),
         "clean" => cmd_clean(),
-        "check" => cmd_check(&args[1..]),
+        "check" => {
+            navigate_to_target_dir(&args[1..]);
+            cmd_check(&args[1..])
+        }
         "build" => {
+            navigate_to_target_dir(&args[1..]);
             apply_linker_flag(&args[1..]);
             let is_release = args.iter().any(|a| a == "--release");
             if cmd_build_opts(is_release).is_some() { 0 } else { 1 }
         }
         "run" => {
+            navigate_to_target_dir(&args[1..]);
             apply_linker_flag(&args[1..]);
             cmd_run()
         }
-        "test" => cmd_test(),
-        "bench" => cmd_bench(),
+        "test" => {
+            navigate_to_target_dir(&args[1..]);
+            cmd_test()
+        }
+        "bench" => {
+            navigate_to_target_dir(&args[1..]);
+            cmd_bench()
+        }
         "login" => cmd_login(&args[1..]),
         "publish" => cmd_publish(&args[1..]),
         "upgrade" | "self-update" | "update-self" => cmd_self_update(&args[1..]),

--- a/tests/cli_tests/test_cli_commands.sh
+++ b/tests/cli_tests/test_cli_commands.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env sh
+set -eu
+
+ROOT=$(CDPATH= cd -- "$(dirname -- "$0")/../.." && pwd)
+LPP="$ROOT/target/release/lpp"
+TEMP=$(mktemp -d "${TMPDIR:-/tmp}/lpp-cli-commands.XXXXXX")
+cleanup() { rm -rf "$TEMP"; }
+trap cleanup EXIT HUP INT TERM
+
+if [ ! -x "$LPP" ]; then
+    (cd "$ROOT" && cargo build --release --bin lpp)
+fi
+
+echo "Testing CLI commands routing..."
+
+# 1. Package command (run) - shouldn't try to parse a file named "run" or directory
+mkdir -p "$TEMP/test_pkg/src"
+cat > "$TEMP/test_pkg/lpp.toml" << 'TOML'
+[package]
+name = "test_pkg"
+version = "0.1.0"
+TOML
+cat > "$TEMP/test_pkg/src/main.lpp" << 'CODE'
+def main():
+    print(1)
+CODE
+(cd "$TEMP/test_pkg" && "$LPP" run >/dev/null)
+echo "PASS run package"
+
+# 2. Source command with .lpp extension
+cat > "$TEMP/example.lpp" << 'CODE'
+def main():
+    print(2)
+CODE
+"$LPP" run "$TEMP/example.lpp" >/dev/null
+echo "PASS run source"
+
+# 3. Source command with path that is a file without extension
+cat > "$TEMP/no_ext" << 'CODE'
+def main():
+    print(3)
+CODE
+"$LPP" run "$TEMP/no_ext" >/dev/null
+echo "PASS run source without extension"
+
+# 4. Package directory path for run command
+(cd "$TEMP" && "$LPP" run test_pkg >/dev/null)
+echo "PASS run package by path"
+
+# 5. Package directory path for check command
+(cd "$TEMP" && "$LPP" check test_pkg >/dev/null)
+echo "PASS check package by path"
+
+# 6. Package directory path for build command
+(cd "$TEMP" && "$LPP" build test_pkg >/dev/null)
+echo "PASS build package by path"
+
+echo "ALL TESTS PASSED"


### PR DESCRIPTION
The CLI was mistakenly parsing commands like `lpp run package_dir` as a source run instead of passing it to the package manager, because it checked if `package_dir` existed but didn't verify it was a file. This caused it to try to parse a directory as source code.
Additionally, the Rust package manager compatibility layer did not actually change to the target package directory when one was provided in the arguments for commands like `check`, `build`, `run`, `test`, and `bench`.

This PR fixes both issues:
- `src/main.rs` now checks `is_file()` before treating an argument as a `.lpp` file source run if it doesn't have the `.lpp` extension.
- `src/pm.rs` has a `navigate_to_target_dir` helper that iterates arguments, finds the target directory, and navigates into it prior to running the commands.
- Added 6 tests to ensure that `run`, `check`, and `build` commands correctly parse source files and navigate into package directories successfully.

---
*PR created automatically by Jules for task [6343873514081651906](https://jules.google.com/task/6343873514081651906) started by @samarofficals*