### PR TITLE
Fix L++ CLI positional directory arguments handling

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -563,13 +563,13 @@ fn real_main() -> i32 {
     let mut source_check_command = false;
     let mut is_emit_cmd = false;
     let mut source_run_command = false;
-    if args.len() > 2 && args[1] == "emit" {
+    if args.len() > 2 && args[1] == "emit" && (args[2].ends_with(".lpp") || Path::new(&args[2]).is_file()) {
         is_emit_cmd = true;
         args.remove(1);
-    } else if args.len() > 2 && args[1] == "check" && args[2].ends_with(".lpp") {
+    } else if args.len() > 2 && args[1] == "check" && (args[2].ends_with(".lpp") || Path::new(&args[2]).is_file()) {
         source_check_command = true;
         args.remove(1);
-    } else if args.len() > 2 && args[1] == "run" && (args[2].ends_with(".lpp") || Path::new(&args[2]).exists()) {
+    } else if args.len() > 2 && args[1] == "run" && (args[2].ends_with(".lpp") || Path::new(&args[2]).is_file()) {
         source_run_command = true;
         args.remove(1);
     }

--- a/src/pm.rs
+++ b/src/pm.rs
@@ -2009,15 +2009,72 @@ pub fn run_command(args: &[String]) -> i32 {
         "outdated" => cmd_outdated(),
         "version" => cmd_version(&args[1..]),
         "clean" => cmd_clean(),
-        "check" => cmd_check(&args[1..]),
+        "check" => {
+            let mut target_dir = None;
+            for arg in &args[1..] {
+                if arg != "check" && !arg.starts_with('-') {
+                    target_dir = Some(arg);
+                    break;
+                }
+            }
+            let restore_dir = std::env::current_dir().ok();
+            if let Some(dir) = target_dir {
+                if let Err(e) = std::env::set_current_dir(dir) {
+                    eprintln!("[L++] Failed to enter directory '{}': {e}", dir);
+                    return 1;
+                }
+            }
+            let res = cmd_check(&args[1..]);
+            if let Some(d) = restore_dir {
+                let _ = std::env::set_current_dir(d);
+            }
+            res
+        }
         "build" => {
+            let mut is_release = false;
+            let mut target_dir = None;
+            for arg in &args[1..] {
+                if arg == "--release" {
+                    is_release = true;
+                } else if arg != "build" && target_dir.is_none() && !arg.starts_with('-') {
+                    target_dir = Some(arg);
+                }
+            }
+            let restore_dir = std::env::current_dir().ok();
+            if let Some(dir) = target_dir {
+                if let Err(e) = std::env::set_current_dir(dir) {
+                    eprintln!("[L++] Failed to enter directory '{}': {e}", dir);
+                    return 1;
+                }
+            }
             apply_linker_flag(&args[1..]);
-            let is_release = args.iter().any(|a| a == "--release");
-            if cmd_build_opts(is_release).is_some() { 0 } else { 1 }
+            let res = if cmd_build_opts(is_release).is_some() { 0 } else { 1 };
+            if let Some(d) = restore_dir {
+                let _ = std::env::set_current_dir(d);
+            }
+            res
         }
         "run" => {
+            let mut target_dir = None;
+            for arg in &args[1..] {
+                if arg != "run" && !arg.starts_with('-') {
+                    target_dir = Some(arg);
+                    break;
+                }
+            }
+            let restore_dir = std::env::current_dir().ok();
+            if let Some(dir) = target_dir {
+                if let Err(e) = std::env::set_current_dir(dir) {
+                    eprintln!("[L++] Failed to enter directory '{}': {e}", dir);
+                    return 1;
+                }
+            }
             apply_linker_flag(&args[1..]);
-            cmd_run()
+            let res = cmd_run();
+            if let Some(d) = restore_dir {
+                let _ = std::env::set_current_dir(d);
+            }
+            res
         }
         "test" => cmd_test(),
         "bench" => cmd_bench(),

--- a/tests/cli_tests/test_cli_commands.sh
+++ b/tests/cli_tests/test_cli_commands.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env sh
+set -eu
+ROOT=$(CDPATH= cd -- "$(dirname -- "$0")/../.." && pwd)
+LPP="$ROOT/target/release/lpp"
+TEMP=$(mktemp -d "${TMPDIR:-/tmp}/lpp-cli-tests.XXXXXX")
+cleanup() { rm -rf "$TEMP"; }
+trap cleanup EXIT HUP INT TERM
+
+if [ ! -x "$LPP" ]; then
+    (cd "$ROOT" && cargo build --release --bin lpp)
+fi
+
+echo "Running tests in emulator mode"
+
+mkdir -p "$TEMP/my_pkg"
+cat > "$TEMP/my_pkg/lpp.toml" << 'TOML'
+[package]
+name = "my_pkg"
+version = "0.1.0"
+TOML
+
+mkdir -p "$TEMP/my_pkg/src"
+cat > "$TEMP/my_pkg/src/main.lpp" << 'LPP'
+def main():
+    print(42)
+LPP
+
+"$LPP" run "$TEMP/my_pkg" > /dev/null
+echo "CLI test 1 passed"
+
+"$LPP" check "$TEMP/my_pkg" > /dev/null
+echo "CLI test 2 passed"
+
+mkdir -p "$TEMP/my_pkg2"
+cat > "$TEMP/my_pkg2/lpp.toml" << 'TOML'
+[package]
+name = "my_pkg2"
+version = "0.1.0"
+TOML
+
+mkdir -p "$TEMP/my_pkg2/src"
+cat > "$TEMP/my_pkg2/src/main.lpp" << 'LPP'
+def main():
+    print(1)
+LPP
+
+"$LPP" run "$TEMP/my_pkg2" > /dev/null
+echo "CLI test 3 passed"
+
+"$LPP" check "$TEMP/my_pkg2" > /dev/null
+echo "CLI test 4 passed"
+
+cat > "$TEMP/my_file.lpp" << 'LPP'
+def main():
+    print(2)
+LPP
+
+"$LPP" run "$TEMP/my_file.lpp" > /dev/null
+echo "CLI test 5 passed"
+
+echo "PASS all CLI tests"


### PR DESCRIPTION
Fixes bug where directories are incorrectly parsed as files when passed as positional arguments to L++ CLI commands like run and check.

---
*PR created automatically by Jules for task [5615223867224976218](https://jules.google.com/task/5615223867224976218) started by @samarofficals*