### PR TITLE
Fix CLI package resolution bug and add tests

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -563,13 +563,13 @@ fn real_main() -> i32 {
     let mut source_check_command = false;
     let mut is_emit_cmd = false;
     let mut source_run_command = false;
-    if args.len() > 2 && args[1] == "emit" {
+    if args.len() > 2 && args[1] == "emit" && Path::new(&args[2]).is_file() {
         is_emit_cmd = true;
         args.remove(1);
-    } else if args.len() > 2 && args[1] == "check" && args[2].ends_with(".lpp") {
+    } else if args.len() > 2 && args[1] == "check" && Path::new(&args[2]).is_file() && args[2].ends_with(".lpp") {
         source_check_command = true;
         args.remove(1);
-    } else if args.len() > 2 && args[1] == "run" && (args[2].ends_with(".lpp") || Path::new(&args[2]).exists()) {
+    } else if args.len() > 2 && args[1] == "run" && Path::new(&args[2]).is_file() {
         source_run_command = true;
         args.remove(1);
     }

--- a/tests/test_cli_commands.sh
+++ b/tests/test_cli_commands.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env sh
+set -eu
+
+ROOT=$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)
+LPP="$ROOT/target/release/lpp"
+TEMP=$(mktemp -d "${TMPDIR:-/tmp}/lpp-cli-commands.XXXXXX")
+cleanup() { rm -rf "$TEMP"; }
+trap cleanup EXIT HUP INT TERM
+
+if ! command -v cargo >/dev/null 2>&1; then
+    echo "SKIP: requires cargo"
+    exit 0
+fi
+if [ ! -x "$LPP" ]; then
+    (cd "$ROOT" && cargo build --release --bin lpp)
+fi
+
+# 1. Package creation (lpp new)
+(cd "$TEMP" && "$LPP" new mypkg)
+[ -d "$TEMP/mypkg/src" ]
+[ -f "$TEMP/mypkg/lpp.toml" ]
+
+# 2. Package build (lpp build)
+(cd "$TEMP/mypkg" && "$LPP" build)
+if [ ! -f "$TEMP/mypkg/LppData/build/release/mypkg" ] && [ ! -f "$TEMP/mypkg/LppData/build/release/mypkg.exe" ]; then
+    echo "Build failed to produce executable"
+    exit 1
+fi
+
+# 3. Package check (lpp check)
+(cd "$TEMP/mypkg" && "$LPP" check)
+
+# 4. Package run (lpp run)
+(cd "$TEMP/mypkg" && LPP_EMULATOR=1 "$LPP" run)
+
+# 5. Invalid command
+if "$LPP" invalid_cmd 2>/dev/null; then
+    echo "FAIL: invalid command should fail"
+    exit 1
+fi
+
+echo "PASS CLI commands"


### PR DESCRIPTION
Fix a bug in the L++ CLI where package directories passed to `emit`, `check`, and `run` commands were being evaluated as single source files. Also added a shell script containing 5 tests explicitly validating the behavior of the CLI.

---
*PR created automatically by Jules for task [9731098391489224653](https://jules.google.com/task/9731098391489224653) started by @samarofficals*