### PR TITLE
Fix FFI test and add CLI commands test

### DIFF
--- a/tests/test_cli_commands.sh
+++ b/tests/test_cli_commands.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+set -euo pipefail
+ROOT=$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)
+LPP="$ROOT/target/release/lpp"
+TEMP=$(mktemp -d)
+cleanup() { rm -rf "$TEMP"; }
+trap cleanup EXIT HUP INT TERM
+
+if [ ! -x "$LPP" ]; then
+    (cd "$ROOT" && cargo build --release --bin lpp)
+fi
+
+cd "$TEMP"
+echo "Test 1: new"
+"$LPP" new mypkg
+cd mypkg
+
+echo "Test 2: check"
+"$LPP" check
+
+echo "Test 3: build"
+"$LPP" build
+
+echo "Test 4: run"
+"$LPP" run
+
+echo "Test 5: test"
+mkdir tests
+cat > tests/test_dummy.lpp <<EOF
+def main():
+    print("test pass")
+EOF
+LPP_EMULATOR=1 "$LPP" test
+
+echo "PASS CLI commands"

--- a/tests/test_ffi.lpp
+++ b/tests/test_ffi.lpp
@@ -2,15 +2,15 @@
 
 extern "C":
     def abs(x: Int) -> Int
-    def _getpid() -> Int
+    def getpid() -> Int
 
 def main():
     # Call C stdlib abs()
     n := abs(-42)
     print(n)
 
-    # Call _getpid()
-    pid := _getpid()
+    # Call getpid()
+    pid := getpid()
     print(pid)
 
     print("ffi works!")


### PR DESCRIPTION
Fixes an issue with `_getpid` missing on Unix during FFI tests. Also introduces a new test script for CLI PM commands.

---
*PR created automatically by Jules for task [18341023766505316185](https://jules.google.com/task/18341023766505316185) started by @samarofficals*