### PR TITLE
test: add CLI commands tests

### DIFF
--- a/tests/test_cli_commands.sh
+++ b/tests/test_cli_commands.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env sh
+# Verify core PM commands and routing
+set -eu
+
+ROOT=$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)
+LPP="$ROOT/target/release/lpp"
+TEMP=$(mktemp -d "${TMPDIR:-/tmp}/lpp-cli-commands.XXXXXX")
+cleanup() { rm -rf "$TEMP"; }
+trap cleanup EXIT HUP INT TERM
+
+if ! command -v cargo >/dev/null 2>&1; then
+    echo "SKIP: requires cargo"
+    exit 0
+fi
+if [ ! -x "$LPP" ]; then
+    (cd "$ROOT" && cargo build --release --bin lpp)
+fi
+
+echo "Testing basic package initialization..."
+cd "$TEMP"
+"$LPP" init my_pkg
+[ -f lpp.toml ]
+[ -f src/main.lpp ]
+
+echo "Testing package run command..."
+OUT=$(LPP_EMULATOR=1 "$LPP" run 2>&1)
+echo "$OUT" | grep -q "Hello" || { echo "Failed to run package"; exit 1; }
+
+echo "Testing package check command..."
+"$LPP" check >/dev/null
+
+echo "Testing lpp version..."
+"$LPP" version >/dev/null
+
+echo "Testing lpp help..."
+"$LPP" help >/dev/null
+
+echo "PASS CLI commands"


### PR DESCRIPTION
This PR implements the requested 5 CLI tests locally, running all CLI tests using the Emulator (`LPP_EMULATOR=1`). The script `tests/test_cli_commands.sh` tests core functionality such as package initialization, code execution, check, version, and help commands.

Note: No bug fixes were applied to the codebase because the L++ cli works correctly.

Tests were successfully executed by running `LPP_EMULATOR=1 sh tests/test_cli_commands.sh` and `cargo test`.

---
*PR created automatically by Jules for task [14786422272256140610](https://jules.google.com/task/14786422272256140610) started by @samarofficals*