### PR TITLE
Fix CLI routing for source vs PM commands

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -563,13 +563,13 @@ fn real_main() -> i32 {
     let mut source_check_command = false;
     let mut is_emit_cmd = false;
     let mut source_run_command = false;
-    if args.len() > 2 && args[1] == "emit" {
+    if args.len() > 2 && args[1] == "emit" && (args[2].ends_with(".lpp") || Path::new(&args[2]).is_file()) {
         is_emit_cmd = true;
         args.remove(1);
-    } else if args.len() > 2 && args[1] == "check" && args[2].ends_with(".lpp") {
+    } else if args.len() > 2 && args[1] == "check" && (args[2].ends_with(".lpp") || Path::new(&args[2]).is_file()) {
         source_check_command = true;
         args.remove(1);
-    } else if args.len() > 2 && args[1] == "run" && (args[2].ends_with(".lpp") || Path::new(&args[2]).exists()) {
+    } else if args.len() > 2 && args[1] == "run" && (args[2].ends_with(".lpp") || Path::new(&args[2]).is_file()) {
         source_run_command = true;
         args.remove(1);
     }

--- a/tests/test_cli_commands.sh
+++ b/tests/test_cli_commands.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env sh
+# Verify the CLI command routing behaves correctly for source vs package manager commands.
+set -eu
+
+ROOT=$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)
+LPP="$ROOT/target/release/lpp"
+TEMP=$(mktemp -d "${TMPDIR:-/tmp}/lpp-cli-commands.XXXXXX")
+cleanup() { rm -rf "$TEMP"; }
+trap cleanup EXIT HUP INT TERM
+
+if ! command -v cargo >/dev/null 2>&1; then
+    echo "SKIP: requires cargo"
+    exit 0
+fi
+
+if [ ! -x "$LPP" ]; then
+    (cd "$ROOT" && cargo build --release --bin lpp)
+fi
+
+RUNNER=""
+if [ "${LPP_EMULATOR:-0}" = "1" ] && [ -n "${WASM_RUNTIME:-}" ]; then
+    RUNNER="$WASM_RUNTIME"
+fi
+
+# 1. Source check
+cat > "$TEMP/script.lpp" <<'EOF'
+def main():
+    print("hello from script")
+EOF
+
+"$LPP" check "$TEMP/script.lpp" >/dev/null
+echo "PASS source check"
+
+# 2. PM check
+mkdir -p "$TEMP/my_pkg/src"
+cat > "$TEMP/my_pkg/lpp.toml" <<'EOF'
+[package]
+name = "my_pkg"
+version = "0.1.0"
+EOF
+cat > "$TEMP/my_pkg/src/main.lpp" <<'EOF'
+def main():
+    print("hello from pm")
+EOF
+
+cd "$TEMP/my_pkg"
+"$LPP" check >/dev/null
+echo "PASS PM check"
+cd "$ROOT"
+
+# 3. Source run
+if [ -n "$RUNNER" ]; then
+    $RUNNER "$LPP" run "$TEMP/script.lpp" >/dev/null
+else
+    "$LPP" run "$TEMP/script.lpp" >/dev/null
+fi
+echo "PASS source run"
+
+# 4. PM run
+cd "$TEMP/my_pkg"
+if [ -n "$RUNNER" ]; then
+    $RUNNER "$LPP" run >/dev/null
+else
+    "$LPP" run >/dev/null
+fi
+echo "PASS PM run"
+cd "$ROOT"
+
+# 5. Source emit
+"$LPP" emit "$TEMP/script.lpp" >/dev/null
+obj_ext="o"
+if [ "$(uname -s)" = "MINGW32_NT" ] || [ "$(uname -s)" = "MINGW64_NT" ] || [ "$(uname -s)" = "MSYS_NT" ]; then
+    obj_ext="obj"
+fi
+[ -e "$TEMP/script.$obj_ext" ]
+echo "PASS source emit"


### PR DESCRIPTION
This submission fixes a bug in `src/main.rs` where CLI command routing logic incorrectly evaluated any existing path for `run`, `check`, and `emit` commands as single-file source commands instead of invoking the package manager for project directories.

- The routing logic has been updated to use `Path::new(...).is_file()` to strictly ensure the path is a file when bypassing package manager execution.
- Added a new automated testing script `tests/test_cli_commands.sh` that covers 5 distinct CLI usage cases (source checks/runs vs package manager checks/runs, and source emit). The script respects `LPP_EMULATOR=1`.
- Tests run successfully locally without regression to any cargo tests or shell tests.

---
*PR created automatically by Jules for task [10860347663097661308](https://jules.google.com/task/10860347663097661308) started by @samarofficals*